### PR TITLE
get storage account of stemcell from instance_id instead of calling get_storage_account_from_vm_properties

### DIFF
--- a/src/bosh_azure_cpi/.rubocop_todo.yml
+++ b/src/bosh_azure_cpi/.rubocop_todo.yml
@@ -225,3 +225,8 @@ Style/NumericPredicate:
 # URISchemes: http, https
 Metrics/LineLength:
   Max: 1214
+
+# Offense count: 1
+Style/IfInsideElse:
+  Exclude:
+    - 'lib/cloud/azure/vms/vm_manager.rb'

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
@@ -46,7 +46,7 @@ module Bosh::AzureCloud
 
       tasks.push(
         task_get_stemcell_info = Concurrent::Future.execute do
-          _get_stemcell_info(bosh_vm_meta.stemcell_cid, vm_props, location)
+          _get_stemcell_info(bosh_vm_meta.stemcell_cid, vm_props, location, instance_id.storage_account_name)
         end
       )
 
@@ -403,7 +403,7 @@ module Bosh::AzureCloud
       instance_id
     end
 
-    def _get_stemcell_info(stemcell_cid, vm_props, location)
+    def _get_stemcell_info(stemcell_cid, vm_props, location, storage_account_name)
       stemcell_info = nil
       if @use_managed_disks
         if is_light_stemcell_cid?(stemcell_cid)
@@ -420,16 +420,14 @@ module Bosh::AzureCloud
           end
         end
       else
-        storage_account = get_storage_account_from_vm_properties(vm_props, location)
-
         if is_light_stemcell_cid?(stemcell_cid)
           raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_cid}' does not exist" unless @light_stemcell_manager.has_stemcell?(location, stemcell_cid)
 
           stemcell_info = @light_stemcell_manager.get_stemcell_info(stemcell_cid)
         else
-          raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_cid}' does not exist" unless @stemcell_manager.has_stemcell?(storage_account[:name], stemcell_cid)
+          raise Bosh::Clouds::VMCreationFailed.new(false), "Given stemcell '#{stemcell_cid}' does not exist" unless @stemcell_manager.has_stemcell?(storage_account_name, stemcell_cid)
 
-          stemcell_info = @stemcell_manager.get_stemcell_info(storage_account[:name], stemcell_cid)
+          stemcell_info = @stemcell_manager.get_stemcell_info(storage_account_name, stemcell_cid)
         end
       end
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_storage.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_storage.rb
@@ -2,6 +2,7 @@
 
 module Bosh::AzureCloud
   class VMManager
+    # This function is not idempotent, make sure it is not called more than once
     def get_storage_account_from_vm_properties(vm_properties, location)
       @logger.debug("get_storage_account_from_vm_properties(#{vm_properties}, #{location})")
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -73,6 +73,8 @@ shared_context 'shared stuff for vm manager' do
   before do
     allow(instance_id).to receive(:vm_name)
       .and_return(vm_name)
+    allow(instance_id).to receive(:storage_account_name)
+      .and_return(storage_account_name)
     allow(instance_id).to receive(:to_s)
       .and_return(instance_id_string)
     allow(vm_manager).to receive(:get_storage_account_from_vm_properties)

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/stemcell_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/stemcell_spec.rb
@@ -64,6 +64,8 @@ describe Bosh::AzureCloud::VMManager do
 
   describe '#get_stemcell_info' do
     context 'when managed disks are used' do
+      let(:storage_account_name) { nil }
+
       context 'when light stemcell is used' do
         let(:stemcell_id) { 'bosh-light-stemcell-xxx' }
 
@@ -74,7 +76,7 @@ describe Bosh::AzureCloud::VMManager do
 
           it 'should raise an error' do
             expect do
-              vm_manager2.send(:_get_stemcell_info, stemcell_id, vm_props, location)
+              vm_manager2.send(:_get_stemcell_info, stemcell_id, vm_props, location, storage_account_name)
             end.to raise_error("Given stemcell '#{stemcell_id}' does not exist")
           end
         end
@@ -89,7 +91,7 @@ describe Bosh::AzureCloud::VMManager do
 
           it 'should return the stemcell info' do
             expect(
-              vm_manager2.send(:_get_stemcell_info, stemcell_id, vm_props, location)
+              vm_manager2.send(:_get_stemcell_info, stemcell_id, vm_props, location, storage_account_name)
             ).to be(stemcell_info)
           end
         end
@@ -109,7 +111,7 @@ describe Bosh::AzureCloud::VMManager do
 
           it 'should return the stemcell info' do
             expect(
-              vm_manager2.send(:_get_stemcell_info, stemcell_id, vm_props, location)
+              vm_manager2.send(:_get_stemcell_info, stemcell_id, vm_props, location, storage_account_name)
             ).to be(stemcell_info)
           end
         end
@@ -125,7 +127,7 @@ describe Bosh::AzureCloud::VMManager do
 
           it 'should return the stemcell info' do
             expect do
-              vm_manager2.send(:_get_stemcell_info, stemcell_id, vm_props, location)
+              vm_manager2.send(:_get_stemcell_info, stemcell_id, vm_props, location, storage_account_name)
             end.to raise_error(/Failed to get the user image information for the stemcell '#{stemcell_id}'/)
           end
         end
@@ -147,6 +149,7 @@ describe Bosh::AzureCloud::VMManager do
 
       context 'when light stemcell is used' do
         let(:stemcell_id) { 'bosh-light-stemcell-xxx' }
+        let(:storage_account_name) { nil }
 
         context 'when stemcell does not exist' do
           before do
@@ -155,7 +158,7 @@ describe Bosh::AzureCloud::VMManager do
 
           it 'should raise an error' do
             expect do
-              vm_manager.send(:_get_stemcell_info, stemcell_id, vm_props, location)
+              vm_manager.send(:_get_stemcell_info, stemcell_id, vm_props, location, storage_account_name)
             end.to raise_error("Given stemcell '#{stemcell_id}' does not exist")
           end
         end
@@ -170,7 +173,7 @@ describe Bosh::AzureCloud::VMManager do
 
           it 'should return the stemcell info' do
             expect(
-              vm_manager.send(:_get_stemcell_info, stemcell_id, vm_props, location)
+              vm_manager.send(:_get_stemcell_info, stemcell_id, vm_props, location, storage_account_name)
             ).to be(stemcell_info)
           end
         end
@@ -178,6 +181,7 @@ describe Bosh::AzureCloud::VMManager do
 
       context 'when heavy stemcell is used' do
         let(:stemcell_id) { 'bosh-stemcell-xxx' }
+        let(:storage_account_name) { 'fake-storage-account-name' }
 
         context 'when it fails to get stemcell' do
           before do
@@ -188,7 +192,7 @@ describe Bosh::AzureCloud::VMManager do
 
           it 'should raise an error' do
             expect do
-              vm_manager.send(:_get_stemcell_info, stemcell_id, vm_props, location)
+              vm_manager.send(:_get_stemcell_info, stemcell_id, vm_props, location, storage_account_name)
             end.to raise_error("Given stemcell '#{stemcell_id}' does not exist")
           end
         end
@@ -207,7 +211,7 @@ describe Bosh::AzureCloud::VMManager do
 
           it 'should return stemcell info' do
             expect(
-              vm_manager.send(:_get_stemcell_info, stemcell_id, vm_props, location)
+              vm_manager.send(:_get_stemcell_info, stemcell_id, vm_props, location, storage_account_name)
             ).to be(stemcell_info)
           end
         end


### PR DESCRIPTION
Fix the issue that stemcell and disks might be in different storage account when `storage_account_name` is with pattern.