### PR TITLE
fix the issue that when other one already created the container.

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/storage/blob_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/storage/blob_manager.rb
@@ -405,7 +405,7 @@ module Bosh::AzureCloud
     rescue StandardError => e
       # create the container if it does not exists
       if e.inspect.include?('ContainerNotFound')
-        @blob_service_client.create_container(container_name, merge_storage_common_options)
+        _create_container(container_name)
         @blob_service_client.create_page_blob(container_name, blob_name, file_size, options)
       else
         raise e
@@ -417,11 +417,18 @@ module Bosh::AzureCloud
     rescue StandardError => e
       # create the container if it does not exists
       if e.inspect.include?('ContainerNotFound')
-        @blob_service_client.create_container(container_name, merge_storage_common_options)
+        _create_container(container_name)
         @blob_service_client.copy_blob_from_uri(container_name, blob_name, source_blob_uri, options)
       else
         raise e
       end
+    end
+
+    def _create_container(container_name)
+      @blob_service_client.create_container(container_name, merge_storage_common_options)
+    rescue StandardError => e
+      # ignore the error that the container already exists.
+      raise e unless e.inspect.include?('ContainerAlreadyExists')
     end
   end
 


### PR DESCRIPTION
when multiple process doing the copy blob or create page when the container not exist.
the second one may got one error 'ContainerAlreadyExists'. should get it pass.