### PR TITLE
Chruby looks for ruby v2.4.4

### DIFF
--- a/ci/tasks/run-az-bats.sh
+++ b/ci/tasks/run-az-bats.sh
@@ -11,7 +11,7 @@ set -e
 
 source pipelines/shared/utils.sh
 source /etc/profile.d/chruby.sh
-chruby 2.1.7
+chruby 2.4.4
 
 metadata="$( cat environment/metadata )"
 mkdir -p bats-config


### PR DESCRIPTION
bosh-cpi-certification bumped installed ruby version to 2.4.4.
https://github.com/cloudfoundry-incubator/bosh-cpi-certification/commit/95ed3d5272ef4026f6fda1a79cd0f982e2b6ba0d