### PR TITLE
Improve documentation for Azure Stack

### DIFF
--- a/docs/advanced/azure-stack/README.md
+++ b/docs/advanced/azure-stack/README.md
@@ -50,7 +50,7 @@ Until [this issue #508](https://github.com/cloudfoundry/bosh-azure-cpi-release/i
 is solved, make sure the `use_managed_disks` property is set to `false`.
 
 This means you'll have to create a storage account [as advised](https://bosh.io/docs/azure-resources/#storage-account)
-and setup the `storage_account` property.
+and set the `storage_account_name` property.
 
 ### Azure Stack Properties
 

--- a/docs/advanced/azure-stack/README.md
+++ b/docs/advanced/azure-stack/README.md
@@ -44,6 +44,14 @@ azure:
   environment: AzureStack
 ```
 
+### Storage Account
+
+Until [this issue #508](https://github.com/cloudfoundry/bosh-azure-cpi-release/issues/508)
+is solved, make sure the `use_managed_disks` property is set to `false`.
+
+This means you'll have to create a storage account [as advised](https://bosh.io/docs/azure-resources/#storage-account)
+and setup the `storage_account` property.
+
 ### Azure Stack Properties
 
 * Domain


### PR DESCRIPTION
Hi there,

After struggling with using managed disks for `bosh create-env` on Azure Stack, I'm submitting here some additions to the Azure Stack documentation so that other operators don't get confused as I have been! :-)

So, here I'm reminding that Azure Stack support for managed disks is not complete enough for BOSH to use it (as stated in #508), and I'm reminding operators to create a storage account prior to deploying their first BOSH Director with `bosh create-env`.

For the record, this PR also relates to cloudfoundry/bosh-deployment#304.

Best,
Benjamin