### PR TITLE
Public IP addresses created on VMs in AZs will use Standard SKU

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -1263,7 +1263,11 @@ module Bosh::AzureCloud
           'idleTimeoutInMinutes' => params[:idle_timeout_in_minutes]
         }
       }
-      public_ip['zones'] = [params[:zone]] unless params[:zone].nil?
+      if params[:zone]
+        public_ip['zones'] = [params[:zone]]
+        public_ip['sku'] = {'name' => 'Standard'}
+        public_ip['properties']['publicIPAllocationMethod'] = 'Static'
+      end
 
       http_put(url, public_ip)
     end
@@ -2099,6 +2103,7 @@ module Bosh::AzureCloud
         ip_address[:name]     = result['name']
         ip_address[:location] = result['location']
         ip_address[:tags]     = result['tags']
+        ip_address[:sku]     = result['sku']['name']
 
         ip_address[:zone] = result['zones'][0] unless result['zones'].nil?
 

--- a/src/bosh_azure_cpi/spec/integration/resources/availability_zone_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/resources/availability_zone_spec.rb
@@ -39,6 +39,7 @@ describe Bosh::AzureCloud::Cloud do
         dynamic_public_ip = @cpi.azure_client.get_public_ip_by_name(@default_resource_group_name, instance_id_obj.vm_name)
         expect(vm[:zone]).to eq(availability_zone)
         expect(dynamic_public_ip[:zone]).to eq(availability_zone)
+        expect(dynamic_public_ip[:sku]).to eq('Standard')
 
         disk_id = @cpi.create_disk(2048, {}, instance_id)
         expect(disk_id).not_to be_nil

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_public_ip_spec.rb
@@ -150,9 +150,10 @@ describe Bosh::AzureCloud::AzureClient do
             'location' => location,
             'properties' => {
               'idleTimeoutInMinutes' => 4,
-              'publicIPAllocationMethod' => 'Dynamic'
+              'publicIPAllocationMethod' => 'Static'  # Standard SKUs require Static
             },
-            'zones' => ['fake-zone']
+            'zones' => ['fake-zone'],
+            'sku' => {'name' => 'Standard'}
           }
         end
 

--- a/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
@@ -51,6 +51,10 @@ describe Bosh::AzureCloud::AzureClient do
           'fqdn' => 'bar',
           'reverseFqdn' => 'ooo'
         }
+      },
+      'sku' => {
+          'name' => 'Basic',
+          'tier' => 'Regional'
       }
     }
   end
@@ -70,7 +74,8 @@ describe Bosh::AzureCloud::AzureClient do
       ip_configuration_id: 'fake-id',
       domain_name_label: 'foo',
       fqdn: 'bar',
-      reverse_fqdn: 'ooo'
+      reverse_fqdn: 'ooo',
+      sku: 'Basic'
     }
   end
 


### PR DESCRIPTION
AZs require IPs to use Standard SKU, but the operators don't tell the
CPI what SKU to use. As a simple workaround, we can see that a VM is
going to placed in a AZ, and therefore you'd have to use Standard SKU
IPs. There may be other times you'd want/need to use the new IP
offering, but this fix only targets this one case.

Signed-off-by: David Stevenson <dstevenson@pivotal.io>

--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

Thanks for submitting a pull request!

All pull request submitters and commit authors must have a Contributor License Agreement (CLA) on-file with us. Please sign the appropriate CLA ([individual](http://cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf) or [corporate](http://cloudfoundry.org/pdfs/CFF_Corporate_CLA.pdf)).

When sending signed CLA please provide your github username in case of individual CLA or the list of github usernames that can make pull requests on behalf of your organization.

If you are confident that you're covered under a Corporate CLA, please make sure you've publicized your membership in the appropriate Github Org, per [these instructions](https://help.github.com/articles/publicizing-or-concealing-organization-membership/).

--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage should keeps at 100%. 

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Automated created public IPs default to Standard SKU for VMs that are placed in an Azure AZ