### PR TITLE
Feature/selective cleaning

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -67,6 +67,9 @@ properties:
   azure.debug_mode:
     description: Enable debug mode to log all raw HTTP requests/responses
     default: false
+  azure.use_default_account_for_cleaning:
+    description: Use the default storage account when cleaning stemcells
+    default: false
   azure.keep_failed_vms:
     description: Enable keeping the VM which failed in provisioning for troubleshooting
     default: false

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -13,6 +13,7 @@
           'parallel_upload_thread_num' => p('azure.parallel_upload_thread_num'),
           'pip_idle_timeout_in_minutes' => p('azure.pip_idle_timeout_in_minutes'),
           'debug_mode' => p('azure.debug_mode'),
+          'use_default_account_for_cleaning' => p('azure.use_default_account_for_cleaning'),
           'keep_failed_vms' => p('azure.keep_failed_vms'),
           'enable_telemetry' => p('azure.enable_telemetry'),
           'enable_vm_boot_diagnostics' => p('azure.enable_vm_boot_diagnostics')

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
@@ -59,6 +59,7 @@ module Bosh::AzureCloud
     attr_reader :ssh_user, :ssh_public_key
     attr_reader :config_disk
     attr_reader :stemcell_api_version
+    attr_reader :use_default_account_for_cleaning
 
     attr_writer :storage_account_name
 
@@ -102,6 +103,10 @@ module Bosh::AzureCloud
       @ssh_public_key = azure_config_hash['ssh_public_key']
 
       @config_disk = ConfigDisk.new(azure_config_hash.fetch('config_disk', 'enabled' => false))
+
+      # Flag to skip looping all storage account in subscription
+      @use_default_account_for_cleaning = false
+      @use_default_account_for_cleaning = azure_config_hash['use_default_account_for_cleaning'] unless azure_config_hash['use_default_account_for_cleaning'].nil?
 
       # A compatible director sends vm.stemcell.api_version in the cpi method call context
       # https://github.com/cloudfoundry/bosh/blob/v268.5.0/src/bosh-director/lib/cloud/external_cpi.rb#L86

--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell/stemcell_manager2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell/stemcell_manager2.rb
@@ -24,12 +24,18 @@ module Bosh::AzureCloud
         @azure_client.delete_user_image(user_image_name)
       end
 
-      # Delete all stemcells with the given stemcell name in all storage accounts
-      storage_accounts = @azure_client.list_storage_accounts
-      storage_accounts.each do |storage_account|
-        storage_account_name = storage_account[:name]
-        @logger.info("Delete stemcell '#{name}' in the storage '#{storage_account_name}'")
-        @blob_manager.delete_blob(storage_account_name, STEMCELL_CONTAINER, "#{name}.vhd") if has_stemcell?(storage_account_name, name)
+      if @storage_account_manager.use_default_account_for_cleaning
+        # Delete a stemcell name in defaukt storage accounts
+        @logger.info("Delete stemcell(#{name}) in default storage account #{@default_storage_account_name}")
+        @blob_manager.delete_blob(@default_storage_account_name, STEMCELL_CONTAINER, "#{name}.vhd") if has_stemcell?(@default_storage_account_name, name)
+      else
+        # Delete all stemcells with the given stemcell name in all storage accounts
+        storage_accounts = @azure_client.list_storage_accounts
+        storage_accounts.each do |storage_account|
+          storage_account_name = storage_account[:name]
+          @logger.info("Delete stemcell '#{name}' in the storage '#{storage_account_name}'")
+          @blob_manager.delete_blob(storage_account_name, STEMCELL_CONTAINER, "#{name}.vhd") if has_stemcell?(storage_account_name, name)
+        end
       end
 
       # Delete all records whose PartitionKey is the given stemcell name

--- a/src/bosh_azure_cpi/lib/cloud/azure/storage/storage_account_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/storage/storage_account_manager.rb
@@ -4,6 +4,7 @@ module Bosh::AzureCloud
   class StorageAccountManager
     include Helpers
 
+    attr_reader :use_default_account_for_cleaning
     def initialize(azure_config, blob_manager, azure_client)
       @azure_config = azure_config
       @blob_manager = blob_manager
@@ -13,6 +14,7 @@ module Bosh::AzureCloud
 
       @default_storage_account_name = nil
       @default_storage_account = nil
+      @use_default_account_for_cleaning = @azure_config.use_default_account_for_cleaning
     end
 
     def generate_storage_account_name

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -71,6 +71,7 @@ describe 'cpi.json.erb' do
             'ssh_public_key' => 'ssh-rsa ABCDEFGHIJKLMN',
             'default_security_group' => 'fake-default-security-group',
             'parallel_upload_thread_num' => 16,
+            'use_default_account_for_cleaning' => false,
             'debug_mode' => false,
             'keep_failed_vms' => false,
             'enable_telemetry' => false,

--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
@@ -13,6 +13,9 @@ describe Bosh::AzureCloud::StemcellManager2 do
   before do
     allow(storage_account_manager).to receive(:default_storage_account_name)
       .and_return(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME)
+
+    allow(storage_account_manager).to receive(:use_default_account_for_cleaning)
+      .and_return(false)
   end
 
   let(:stemcell_uuid) { 'fbb636e9-89b6-432b-b52c-b5cd93654900' }


### PR DESCRIPTION
This PR circumvents the issue when having a locked down (subnet access) storage accounts. The process of cleaning of stemcell fails. For more details check #612

[X ] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage should keeps at 100%. 

### Changelog

* A new propriety `use_default_account_for_cleaning` was added to always use default account for cleaning. By default the flag is disabled and same code path and functionality is maintained. When enabled stemcells are only deleted from default storage account only.

Thank you 👍 

