### PR TITLE
Raise an error when network interface is misconfigured

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -1463,6 +1463,12 @@ module Bosh::AzureCloud
 
       load_balancer = nic_params[:load_balancer]
       unless load_balancer.nil?
+        if load_balancer[:backend_address_pools].empty?
+          raise AzureError, "No backend address pools are associated with the load balancer"
+        end
+        if load_balancer[:frontend_ip_configurations].empty?
+          raise AzureError, "No frontend IP configurations are associated with the load balancer"
+        end
         interface['properties']['ipConfigurations'][0]['properties']['loadBalancerBackendAddressPools'] = [
           {
             'id' => load_balancer[:backend_address_pools][0][:id]
@@ -1474,6 +1480,9 @@ module Bosh::AzureCloud
 
       application_gateway = nic_params[:application_gateway]
       unless application_gateway.nil?
+        if application_gateway[:backend_address_pools].empty?
+          raise AzureError, "No backend address pools are associated with the application gateway"
+        end
         interface['properties']['ipConfigurations'][0]['properties']['applicationGatewayBackendAddressPools'] = [
           {
             'id' => application_gateway[:backend_address_pools][0][:id]

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
@@ -363,6 +363,30 @@ describe Bosh::AzureCloud::AzureClient do
             azure_client.create_network_interface(resource_group, nic_params)
           end.not_to raise_error
         end
+
+        context 'with no backend address pools' do
+          let(:nic_params) do
+            super().tap { |p| p[:load_balancer][:backend_address_pools] = [] }
+          end
+
+          it 'raises an exception with an appropriate error message' do
+            expect do
+              azure_client.create_network_interface(resource_group, nic_params)
+            end.to raise_error(Bosh::AzureCloud::AzureError, /No backend address pools/)
+          end
+        end
+
+        context 'with no frontend IP configurations' do
+          let(:nic_params) do
+            super().tap { |p| p[:load_balancer][:frontend_ip_configurations] = [] }
+          end
+
+          it 'raises an exception with an appropriate error message' do
+            expect do
+              azure_client.create_network_interface(resource_group, nic_params)
+            end.to raise_error(Bosh::AzureCloud::AzureError, /No frontend IP configurations/)
+          end
+        end
       end
 
       context 'with application security groups' do
@@ -537,6 +561,18 @@ describe Bosh::AzureCloud::AzureClient do
           expect do
             azure_client.create_network_interface(resource_group, nic_params)
           end.not_to raise_error
+        end
+
+        context 'with no backend address pools' do
+          let(:nic_params) do
+            super().tap { |p| p[:application_gateway][:backend_address_pools] = [] }
+          end
+
+          it 'raises an exception with an appropriate error message' do
+            expect do
+              azure_client.create_network_interface(resource_group, nic_params)
+            end.to raise_error(Bosh::AzureCloud::AzureError, /No backend address pools/)
+          end
         end
       end
     end


### PR DESCRIPTION
If a specified load balancer is misconfigured such that it doesn't have
any backend address pools the CPI raises this cryptic error:

```
  #<NoMethodError: undefined method `[]' for nil:NilClass>
```

This changes `AzureClient#create_network_interface` to validate the
`nic_params` argument when `load_balancer` or `application_gateway` is
used so that a more semantic error message can be raised.

- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage should keeps at 100%. 