### PR TITLE
Do not merge existing VM tags with custom tags

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -516,7 +516,7 @@ module Bosh::AzureCloud
       raise AzureNotFoundError, "update_tags_of_virtual_machine - cannot find the virtual machine by name '#{name}' in resource group '#{resource_group_name}'" if vm.nil?
 
       vm = remove_resources_from_vm(vm)
-      vm['tags'].merge!(tags)
+      vm['tags'] = tags
       http_put(url, vm)
     end
 

--- a/src/bosh_azure_cpi/spec/unit/azure_client/update_tags_of_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/update_tags_of_virtual_machine_spec.rb
@@ -67,14 +67,14 @@ describe Bosh::AzureCloud::AzureClient do
             'id' => 'fake-id',
             'name' => 'fake-name',
             'location' => 'fake-location',
-            'tags' => tags.merge(exiting_tags),
+            'tags' => tags,
             'properties' => {
               'provisioningState' => 'fake-state'
             }
           }
         end
 
-        it 'should merge the custom tags with existing tags' do
+        it 'should replace the existing tags with custom tags' do
           stub_request(:post, token_uri).to_return(
             status: 200,
             body: {


### PR DESCRIPTION
Bosh will always manage the tags for a VM. If other tags are added to
bosh-managed resources, then the tags will now be removed.

There is some risk to this PR, as it's mutually exclusive from existing behaviour of upserting existing tags on a VM. I've created this as a PR to increase visibility for this decision.

Fixes #624, https://www.pivotaltracker.com/story/show/170685180
