### PR TITLE
UPDATE enable https traffic only as default

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
@@ -15,7 +15,7 @@ module Bosh::AzureCloud
     attr_reader :security_group
     attr_reader :application_security_groups
     attr_reader :assign_dynamic_public_ip, :ip_forwarding, :accelerated_networking
-    attr_reader :storage_account_name, :storage_account_type, :storage_account_kind, :storage_account_max_disk_number
+    attr_reader :storage_account_name, :storage_account_type, :storage_account_kind, :storage_account_max_disk_number, :storage_https_traffic
     attr_reader :resource_group_name
     attr_reader :tags
 
@@ -74,6 +74,7 @@ module Bosh::AzureCloud
       @storage_account_kind = vm_properties.fetch('storage_account_kind', STORAGE_ACCOUNT_KIND_GENERAL_PURPOSE_V1)
       @storage_account_type = vm_properties['storage_account_type']
       @storage_account_max_disk_number = vm_properties.fetch('storage_account_max_disk_number', 30)
+      @storage_https_traffic = vm_properties.fetch('storage_https_traffic', true)
 
       @resource_group_name = vm_properties.fetch('resource_group_name', global_azure_config.resource_group_name)
       @tags = vm_properties.fetch('tags', {})

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -1756,7 +1756,10 @@ module Bosh::AzureCloud
           'name' => sku
         },
         'kind' => kind,
-        'tags' => tags
+        'tags' => tags,
+        'properties': {
+          'supportsHttpsTrafficOnly': true
+        }
       }
 
       uri = http_url(url)

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -1736,19 +1736,20 @@ module Bosh::AzureCloud
     # Storage/StorageAccounts
 
     # Create a storage account
-    # @param [String] name     - Name of storage account.
-    # @param [String] location - Location where the storage account will be created.
-    # @param [String] sku      - SKU of storage account. In older versions, sku name was called accountType.
-    #                            Options: Standard_LRS, Standard_ZRS, Standard_GRS, Standard_RAGRS or Premium_LRS.
-    # @param [String] kind     - Kind of storage account.
-    # @param [Hash]   tags     - Tags of storage account.
+    # @param [String] name            - Name of storage account.
+    # @param [String] location        - Location where the storage account will be created.
+    # @param [String] sku             - SKU of storage account. In older versions, sku name was called accountType.
+    #                                   Options: Standard_LRS, Standard_ZRS, Standard_GRS, Standard_RAGRS or Premium_LRS.
+    # @param [String] kind            - Kind of storage account.
+    # @param [Hash]   tags            - Tags of storage account.
+    # @param [Boolean] https_traffic  - Enable / Disable secure https traffic.
     #
     # @return [Boolean]
     #
     # @See https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/resource-manager/Microsoft.Storage/stable/2017-10-01/storage.json
     #      https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/resource-manager/Microsoft.Storage/stable/2016-01-01/storage.json
     #
-    def create_storage_account(name, location, sku, kind, tags)
+    def create_storage_account(name, location, sku, kind, tags, https_traffic)
       url = rest_api_url(REST_API_PROVIDER_STORAGE, REST_API_STORAGE_ACCOUNTS, name: name)
       storage_account = {
         'location' => location,
@@ -1758,7 +1759,7 @@ module Bosh::AzureCloud
         'kind' => kind,
         'tags' => tags,
         'properties': {
-          'supportsHttpsTrafficOnly': true
+          'supportsHttpsTrafficOnly': https_traffic
         }
       }
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell/stemcell_manager2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell/stemcell_manager2.rb
@@ -48,16 +48,16 @@ module Bosh::AzureCloud
       !blob_properties.nil?
     end
 
-    def get_user_image_info(stemcell_name, storage_account_type, location)
-      @logger.info("get_user_image_info(#{stemcell_name}, #{storage_account_type}, #{location})")
-      user_image = _get_user_image(stemcell_name, storage_account_type, location)
+    def get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
+      @logger.info("get_user_image_info(#{stemcell_name}, #{storage_account_type}, #{location}, #{https_traffic})")
+      user_image = _get_user_image(stemcell_name, storage_account_type, location, https_traffic)
       StemcellInfo.new(user_image[:id], user_image[:tags])
     end
 
     private
 
-    def _get_user_image(stemcell_name, storage_account_type, location)
-      @logger.info("_get_user_image(#{stemcell_name}, #{storage_account_type}, #{location})")
+    def _get_user_image(stemcell_name, storage_account_type, location, https_traffic)
+      @logger.info("_get_user_image(#{stemcell_name}, #{storage_account_type}, #{location}, #{https_traffic})")
 
       # The old user image name's length exceeds 80 in some location, which would cause the creation failure.
       # Old format: bosh-stemcell-<UUID>-Standard_LRS-<LOCATION>, bosh-stemcell-<UUID>-Premium_LRS-<LOCATION>
@@ -80,7 +80,7 @@ module Bosh::AzureCloud
       else
         # The storage account will only be used when preparing a stemcell in the target location for user image, ANY storage account type is ok.
         # To make it consistent, 'Standard_LRS' is used.
-        storage_account = @storage_account_manager.get_or_create_storage_account_by_tags(STEMCELL_STORAGE_ACCOUNT_TAGS, STORAGE_ACCOUNT_TYPE_STANDARD_LRS, STORAGE_ACCOUNT_KIND_GENERAL_PURPOSE_V1, location, [STEMCELL_CONTAINER], false)
+        storage_account = @storage_account_manager.get_or_create_storage_account_by_tags(STEMCELL_STORAGE_ACCOUNT_TAGS, STORAGE_ACCOUNT_TYPE_STANDARD_LRS, STORAGE_ACCOUNT_KIND_GENERAL_PURPOSE_V1, location, [STEMCELL_CONTAINER], false, https_traffic)
         storage_account_name = storage_account[:name]
 
         flock("#{CPI_LOCK_COPY_STEMCELL}-#{stemcell_name}-#{storage_account_name}", File::LOCK_EX) do

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
@@ -459,8 +459,9 @@ module Bosh::AzureCloud
         else
           begin
             storage_account_type = _get_root_disk_type(vm_props)
+            storage_https_traffic = vm_props.storage_https_traffic
             # Treat user_image_info as stemcell_info
-            stemcell_info = @stemcell_manager2.get_user_image_info(stemcell_cid, storage_account_type, location)
+            stemcell_info = @stemcell_manager2.get_user_image_info(stemcell_cid, storage_account_type, location, storage_https_traffic)
           rescue StandardError => e
             raise Bosh::Clouds::VMCreationFailed.new(false), "Failed to get the user image information for the stemcell '#{stemcell_cid}': #{e.inspect}\n#{e.backtrace.join("\n")}"
           end

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_storage.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_storage.rb
@@ -48,8 +48,9 @@ module Bosh::AzureCloud
           storage_account_name = vm_properties.storage_account_name
           storage_account_type = vm_properties.storage_account_type
           storage_account_kind = vm_properties.storage_account_kind
+          storage_https_traffic = vm_properties.storage_https_traffic
           # Create the storage account automatically if the storage account in vm_types or vm_extensions does not exist
-          storage_account = @storage_account_manager.get_or_create_storage_account(storage_account_name, {}, storage_account_type, storage_account_kind, location, [DISK_CONTAINER, STEMCELL_CONTAINER], false)
+          storage_account = @storage_account_manager.get_or_create_storage_account(storage_account_name, {}, storage_account_type, storage_account_kind, location, [DISK_CONTAINER, STEMCELL_CONTAINER], false, storage_https_traffic)
         end
       else
         storage_account_name = @storage_account_manager.default_storage_account_name

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_storage_account_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_storage_account_spec.rb
@@ -26,6 +26,7 @@ describe Bosh::AzureCloud::AzureClient do
   let(:sku) { 'Standard_LRS' }
   let(:kind) { 'StorageV2' }
   let(:tags) { { 'foo' => 'bar' } }
+  let(:https_traffic) { true }
 
   let(:request_id) { 'fake-request-id' }
   let(:operation_status_link) { "https://management.azure.com/subscriptions/#{subscription_id}/operations/#{request_id}" }
@@ -41,7 +42,7 @@ describe Bosh::AzureCloud::AzureClient do
         kind: kind,
         tags: tags,
         properties: {
-          supportsHttpsTrafficOnly: true
+          supportsHttpsTrafficOnly: https_traffic
         }
       }
     end
@@ -63,7 +64,7 @@ describe Bosh::AzureCloud::AzureClient do
         )
 
         expect(
-          azure_client.create_storage_account(storage_account_name, location, sku, kind, tags)
+          azure_client.create_storage_account(storage_account_name, location, sku, kind, tags, https_traffic)
         ).to be(true)
       end
     end
@@ -85,7 +86,7 @@ describe Bosh::AzureCloud::AzureClient do
         )
 
         expect do
-          azure_client.create_storage_account(storage_account_name, location, sku, kind, tags)
+          azure_client.create_storage_account(storage_account_name, location, sku, kind, tags, https_traffic)
         end.to raise_error(/create_storage_account - Cannot create the storage account '#{storage_account_name}'. http code: 404/)
       end
     end
@@ -119,7 +120,7 @@ describe Bosh::AzureCloud::AzureClient do
 
             expect(azure_client).to receive(:sleep).with(default_retry_after)
             expect(
-              azure_client.create_storage_account(storage_account_name, location, sku, kind, tags)
+              azure_client.create_storage_account(storage_account_name, location, sku, kind, tags, https_traffic)
             ).to be(true)
           end
         end
@@ -150,7 +151,7 @@ describe Bosh::AzureCloud::AzureClient do
 
               expect(azure_client).to receive(:sleep).with(default_retry_after)
               expect do
-                azure_client.create_storage_account(storage_account_name, location, sku, kind, tags)
+                azure_client.create_storage_account(storage_account_name, location, sku, kind, tags, https_traffic)
               end.to raise_error(/Error message: {"status":"Failed"}/)
             end
           end
@@ -189,7 +190,7 @@ describe Bosh::AzureCloud::AzureClient do
                 expect(azure_client).to receive(:sleep).with(default_retry_after).exactly(2).times
                 expect(azure_client).to receive(:sleep).with(1).exactly(1).times
                 expect(
-                  azure_client.create_storage_account(storage_account_name, location, sku, kind, tags)
+                  azure_client.create_storage_account(storage_account_name, location, sku, kind, tags, https_traffic)
                 ).to be(true)
               end
             end
@@ -228,7 +229,7 @@ describe Bosh::AzureCloud::AzureClient do
                 expect(azure_client).to receive(:sleep).with(default_retry_after).exactly(11).times
                 expect(azure_client).to receive(:sleep).with(1).exactly(11).times
                 expect do
-                  azure_client.create_storage_account(storage_account_name, location, sku, kind, tags)
+                  azure_client.create_storage_account(storage_account_name, location, sku, kind, tags, https_traffic)
                 end.to raise_error(Bosh::AzureCloud::AzureAsynInternalError, /create_storage_account - http code: 200/)
               end
             end
@@ -261,7 +262,7 @@ describe Bosh::AzureCloud::AzureClient do
 
           expect(azure_client).to receive(:sleep).with(default_retry_after)
           expect do
-            azure_client.create_storage_account(storage_account_name, location, sku, kind, tags)
+            azure_client.create_storage_account(storage_account_name, location, sku, kind, tags, https_traffic)
           end.to raise_error(/create_storage_account - http code: 404. Error message: fake-response-body/)
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_storage_account_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_storage_account_spec.rb
@@ -39,7 +39,10 @@ describe Bosh::AzureCloud::AzureClient do
           name: sku
         },
         kind: kind,
-        tags: tags
+        tags: tags,
+        properties: {
+          supportsHttpsTrafficOnly: true
+        }
       }
     end
 

--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
@@ -114,6 +114,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
         'foo' => 'bar'
       }
     end
+    let(:https_traffic) { true }
     let(:user_image) do
       {
         id: user_image_id,
@@ -135,7 +136,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
 
       it 'should return the user image information' do
         expect(storage_account_manager).not_to receive(:default_storage_account)
-        stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+        stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
         expect(stemcell_info.uri).to eq(user_image_id)
         expect(stemcell_info.metadata).to eq(tags)
       end
@@ -161,7 +162,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
 
         it 'should raise an error' do
           expect do
-            stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+            stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
           end.to raise_error /Failed to get user image for the stemcell '#{stemcell_name}'/
         end
       end
@@ -217,7 +218,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
               expect(azure_client).not_to receive(:list_storage_accounts)
               expect(stemcell_manager2).to receive(:flock).with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX).and_call_original
               expect(azure_client).to receive(:create_user_image)
-              stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+              stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
               expect(stemcell_info.uri).to eq(user_image_id)
               expect(stemcell_info.metadata).to eq(tags)
             end
@@ -234,7 +235,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
               expect(azure_client).not_to receive(:list_storage_accounts)
               expect(stemcell_manager2).to receive(:flock).with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX).and_call_original
               expect(azure_client).not_to receive(:create_user_image)
-              stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+              stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
               expect(stemcell_info.uri).to eq(user_image_id)
               expect(stemcell_info.metadata).to eq(tags)
             end
@@ -297,7 +298,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
                   .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
                   .and_call_original
                 expect(azure_client).to receive(:create_user_image)
-                stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
                 expect(stemcell_info.uri).to eq(user_image_id)
                 expect(stemcell_info.metadata).to eq(tags)
               end
@@ -330,7 +331,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
                   expect(blob_manager).to receive(:copy_blob)
                     .with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
                   expect(azure_client).to receive(:create_user_image)
-                  stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                  stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
                   expect(stemcell_info.uri).to eq(user_image_id)
                   expect(stemcell_info.metadata).to eq(tags)
                 end
@@ -351,7 +352,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
                     .with("#{CPI_LOCK_COPY_STEMCELL}-#{stemcell_name}-#{existing_storage_account_name}", File::LOCK_EX)
                     .and_call_original
                   expect do
-                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
                   end.to raise_error /Error when copying blobs/
                 end
               end
@@ -369,7 +370,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
 
                 it 'raise an error' do
                   expect do
-                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                    stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
                   end.to raise_error /Error when creating storage account/
                 end
               end
@@ -415,7 +416,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
 
               it 'should create a new user image and return the user image information' do
                 expect(storage_account_manager).to receive(:get_or_create_storage_account_by_tags)
-                  .with(STEMCELL_STORAGE_ACCOUNT_TAGS, storage_account_type, 'Storage', location, ['stemcell'], false)
+                  .with(STEMCELL_STORAGE_ACCOUNT_TAGS, storage_account_type, 'Storage', location, ['stemcell'], false, true)
                   .and_return(storage_account)
                 expect(stemcell_manager2).to receive(:flock)
                   .with("#{CPI_LOCK_COPY_STEMCELL}-#{stemcell_name}-#{new_storage_account_name}", File::LOCK_EX)
@@ -425,7 +426,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
                   .and_call_original
                 expect(blob_manager).to receive(:copy_blob)
                 expect(azure_client).to receive(:create_user_image)
-                stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
                 expect(stemcell_info.uri).to eq(user_image_id)
                 expect(stemcell_info.metadata).to eq(tags)
               end
@@ -468,7 +469,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
               expect(azure_client).to receive(:create_user_image)
 
               expect do
-                stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+                stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
               end.to raise_error(/get_user_image: Can not find a user image with the name '#{user_image_name}'/)
             end
           end
@@ -496,7 +497,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
                 .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
                 .and_call_original
               expect(azure_client).to receive(:create_user_image)
-              stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
+              stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location, https_traffic)
               expect(stemcell_info.uri).to eq(user_image_id)
               expect(stemcell_info.metadata).to eq(tags)
             end

--- a/src/bosh_azure_cpi/spec/unit/storage_account_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/storage_account_manager_spec.rb
@@ -64,6 +64,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
     let(:tags) { { 'foo' => 'bar' } }
     let(:containers) { %w[bosh stemcell] }
     let(:is_default_storage_account) { false }
+    let(:https_traffic) { true }
 
     let(:storage_account) { double('storage-account') }
 
@@ -81,7 +82,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
       it 'should return the storage account' do
         expect(
-          storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account)
+          storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
         ).to be(storage_account)
       end
     end
@@ -102,7 +103,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
         it 'should raise an error' do
           expect do
-            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account)
+            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           end.to raise_error(/The storage account name '#{name}' is invalid./)
         end
       end
@@ -122,7 +123,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
         it 'should raise an error' do
           expect do
-            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account)
+            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           end.to raise_error(/The storage account with the name '#{name}' is not available/)
         end
       end
@@ -138,7 +139,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
         it 'should raise an error' do
           expect do
-            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account)
+            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           end.to raise_error(/Require name to create a new storage account/)
         end
       end
@@ -154,7 +155,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
         it 'should raise an error' do
           expect do
-            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account)
+            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           end.to raise_error(/Require type to create a new storage account/)
         end
       end
@@ -170,7 +171,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
         it 'should raise an error' do
           expect do
-            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account)
+            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           end.to raise_error(/Require location to create a new storage account/)
         end
       end
@@ -185,9 +186,9 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
         it 'should create the storage account' do
           expect(azure_client).to receive(:create_storage_account)
-            .with(name, location, type, kind, tags)
+            .with(name, location, type, kind, tags, https_traffic)
           expect(
-            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account)
+            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           ).to be(storage_account)
         end
       end
@@ -199,13 +200,13 @@ describe Bosh::AzureCloud::StorageAccountManager do
           allow(storage_account_manager).to receive(:find_storage_account_by_name).and_return(nil, nil)
           allow(azure_client).to receive(:check_storage_account_name_availability).with(name).and_return(result)
           allow(azure_client).to receive(:create_storage_account)
-            .with(name, location, type, kind, tags)
+            .with(name, location, type, kind, tags, https_traffic)
             .and_return(true)
         end
 
         it 'should raise an error' do
           expect do
-            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account)
+            storage_account_manager.get_or_create_storage_account(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           end.to raise_error(/Storage account '#{name}' is not created/)
         end
       end
@@ -220,6 +221,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
     let(:containers) { ['bosh'] }
     let(:is_default_storage_account) { false }
     let(:storage_account) { { name: 'fake-name' } }
+    let(:https_traffic) { true }
 
     before do
       expect(storage_account_manager).to receive(:flock)
@@ -236,7 +238,7 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
       it 'should return the storage account directly' do
         expect(
-          storage_account_manager.get_or_create_storage_account_by_tags(tags, type, kind, location, containers, is_default_storage_account)
+          storage_account_manager.get_or_create_storage_account_by_tags(tags, type, kind, location, containers, is_default_storage_account, https_traffic)
         ).to be(storage_account)
       end
     end
@@ -254,28 +256,28 @@ describe Bosh::AzureCloud::StorageAccountManager do
 
       it 'should create a new storage account' do
         expect(storage_account_manager).to receive(:get_or_create_storage_account)
-          .with(name, tags, type, kind, location, containers, is_default_storage_account)
+          .with(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           .and_return(storage_account)
         expect(
-          storage_account_manager.get_or_create_storage_account_by_tags(tags, type, kind, location, containers, is_default_storage_account)
+          storage_account_manager.get_or_create_storage_account_by_tags(tags, type, kind, location, containers, is_default_storage_account, https_traffic)
         ).to be(storage_account)
       end
 
       it 'should raise an error if it fails to get the storage account after creating' do
         expect(storage_account_manager).to receive(:get_or_create_storage_account)
-          .with(name, tags, type, kind, location, containers, is_default_storage_account)
+          .with(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           .and_return(nil)
         expect do
-          storage_account_manager.get_or_create_storage_account_by_tags(tags, type, kind, location, containers, is_default_storage_account)
+          storage_account_manager.get_or_create_storage_account_by_tags(tags, type, kind, location, containers, is_default_storage_account, https_traffic)
         end.to raise_error(/Storage account for tags '#{tags}' is not created/)
       end
 
       it 'should raise an error if it fails to create a new storage account' do
         expect(storage_account_manager).to receive(:get_or_create_storage_account)
-          .with(name, tags, type, kind, location, containers, is_default_storage_account)
+          .with(name, tags, type, kind, location, containers, is_default_storage_account, https_traffic)
           .and_raise('failed to create storage account')
         expect do
-          storage_account_manager.get_or_create_storage_account_by_tags(tags, type, kind, location, containers, is_default_storage_account)
+          storage_account_manager.get_or_create_storage_account_by_tags(tags, type, kind, location, containers, is_default_storage_account, https_traffic)
         end.to raise_error(/failed to create storage account/)
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -43,6 +43,7 @@ shared_context 'shared stuff for vm manager' do
   # Parameters of create
   let(:instance_id) { instance_double(Bosh::AzureCloud::InstanceId) }
   let(:location) { 'fake-location' }
+  let(:https_traffic) { true }
   let(:agent_id) { 'fake-agent-id' }
   let(:stemcell_cid) { 'fake-stemcell-id' }
   let(:bosh_vm_meta) { Bosh::AzureCloud::BoshVMMeta.new(agent_id, stemcell_cid) }

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/stemcell_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/stemcell_spec.rb
@@ -109,7 +109,7 @@ describe Bosh::AzureCloud::VMManager do
 
           before do
             allow(stemcell_manager2).to receive(:get_user_image_info)
-              .with(stemcell_cid, 'Standard_LRS', location)
+              .with(stemcell_cid, 'Standard_LRS', location, https_traffic)
               .and_return(stemcell_info)
           end
 
@@ -125,7 +125,7 @@ describe Bosh::AzureCloud::VMManager do
 
           before do
             allow(stemcell_manager2).to receive(:get_user_image_info)
-              .with(stemcell_cid, 'Standard_LRS', location)
+              .with(stemcell_cid, 'Standard_LRS', location, https_traffic)
               .and_raise('fake-error')
           end
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/get_storage_account_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/get_storage_account_spec.rb
@@ -54,13 +54,14 @@ describe Bosh::AzureCloud::VMManager do
             'instance_type' => 'fake-vm-size',
             'storage_account_name' => storage_account_name,
             'storage_account_type' => 'fake-storage_account_type',
-            'storage_account_kind' => 'StorageV2'
+            'storage_account_kind' => 'StorageV2',
+            'storage_https_traffic' => true
           )
         end
 
         it 'should try to get or create the storage account' do
           expect(storage_account_manager).to receive(:get_or_create_storage_account)
-            .with(storage_account_name, {}, 'fake-storage_account_type', 'StorageV2', location, %w[bosh stemcell], false)
+            .with(storage_account_name, {}, 'fake-storage_account_type', 'StorageV2', location, %w[bosh stemcell], false, true)
             .and_return(storage_account)
           expect(
             vm_manager.get_storage_account_from_vm_properties(vm_props, location)


### PR DESCRIPTION
Hi all, 


- [x]  Please check this box and fill the data as below once you have run the unit tests.
      Code coverage should keeps at 100%. 
```
pushd src/bosh_azure_cpi
  ./bin/test-unit
popd
```

### Changelog

* Add supportsHttpsTrafficOnly (true) as default 
If you check the documentation you will see that the property will be also true as default when you're using API Version > 2019-04-01
https://docs.microsoft.com/en-us/rest/api/storagerp/storageaccounts/create#storageaccountcreateparameters
Thats also the reason why I didn't add a parameter to disable / toggle the setting.

Kind regards