### PR TITLE
Initial Ultra SSD support

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
@@ -16,6 +16,7 @@ module Bosh::AzureCloud
     attr_reader :application_security_groups
     attr_reader :assign_dynamic_public_ip, :ip_forwarding, :accelerated_networking
     attr_reader :storage_account_name, :storage_account_type, :storage_account_kind, :storage_account_max_disk_number
+    attr_reader :enable_ultra_ssd
     attr_reader :resource_group_name
     attr_reader :tags
 
@@ -74,6 +75,8 @@ module Bosh::AzureCloud
       @storage_account_kind = vm_properties.fetch('storage_account_kind', STORAGE_ACCOUNT_KIND_GENERAL_PURPOSE_V1)
       @storage_account_type = vm_properties['storage_account_type']
       @storage_account_max_disk_number = vm_properties.fetch('storage_account_max_disk_number', 30)
+
+      @enable_ultra_ssd = vm_properties.fetch('enable_ultra_ssd', nil)
 
       @resource_group_name = vm_properties.fetch('resource_group_name', global_azure_config.resource_group_name)
       @tags = vm_properties.fetch('tags', {})

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -323,6 +323,12 @@ module Bosh::AzureCloud
         }
       }
 
+      unless vm_params[:enable_ultra_ssd].nil?
+        vm['properties']['additionalCapabilities'] = {
+          'ultraSSDEnabled' => vm_params[:enable_ultra_ssd]
+        }
+      end
+
       unless vm_params[:identity].nil?
         identity_type = vm_params[:identity][:type]
         if identity_type == MANAGED_IDENTITY_TYPE_USER_ASSIGNED

--- a/src/bosh_azure_cpi/lib/cloud/azure/utils/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/utils/helpers.rb
@@ -19,7 +19,7 @@ module Bosh::AzureCloud
         'resourceManagerEndpointUrl' => 'https://management.azure.com/',
         'activeDirectoryEndpointUrl' => 'https://login.microsoftonline.com',
         'apiVersion' => {
-          AZURE_RESOURCE_PROVIDER_COMPUTE => '2018-04-01',
+          AZURE_RESOURCE_PROVIDER_COMPUTE => '2021-07-01',
           AZURE_RESOURCE_PROVIDER_NETWORK => '2017-09-01',
           AZURE_RESOURCE_PROVIDER_STORAGE => '2017-10-01',
           AZURE_RESOURCE_PROVIDER_GROUP => '2016-06-01',

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
@@ -133,6 +133,10 @@ module Bosh::AzureCloud
         managed: @use_managed_disks
       }
 
+      unless vm_props.enable_ultra_ssd.nil?
+        vm_params[:enable_ultra_ssd] = vm_props.enable_ultra_ssd
+      end
+
       unless vm_props.managed_identity.nil?
         vm_params[:identity] = {
           type: vm_props.managed_identity.type,


### PR DESCRIPTION
Currenty only supports enabling ultra ssd compatibility.
No work has been performed on attaching ultra ssd disks via BOSH.

Docs can be found here: https://docs.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd?tabs=azure-portal