### PR TITLE
Make agent credentials optional for accessing blobstore with signed URLs enabled

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -112,6 +112,16 @@ cd ~/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi
 
 If unit tests are passed, you can create a dev release and deploy it for tests.
 
+#### Running ERB job templates unit tests
+
+The ERB templates rendered by the jobs of this Bosh Release have specific unit
+tests that are run along with the other unit tests as instructed above. When
+required, you can run them separately though, with this command:
+
+```bash
+./src/bosh_azure_cpi/bin/test-unit --spec spec/unit/bosh_release
+```
+
 ### CI Pipeline
 
 You can setup a [CI pipeline](../ci/) to run the [integration tests](https://github.com/cloudfoundry/bosh-azure-cpi-release/tree/master/src/bosh_azure_cpi/spec/integration) and [BATs](https://github.com/cloudfoundry/bosh-acceptance-tests/tree/gocli-bats). It's optional for submitting a PR and required for publishing a new CPI release.

--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -144,9 +144,13 @@ properties:
     description: Port of blobstore server used by simple blobstore plugin
     default: 25250
   blobstore.agent.user:
-    description: Username agent uses to connect to blobstore used by simple blobstore plugin
+    description: |
+      Username agent uses to connect to blobstore used by simple blobstore
+      plugin (Optional)
   blobstore.agent.password:
-    description: Password agent uses to connect to blobstore used by simple blobstore plugin
+    description: |
+      Password agent uses to connect to blobstore used by simple blobstore
+      plugin (Required only when user is provided)
 
   agent.blobstore.secret_access_key:
     description: AWS secret_access_key for agent used by s3 blobstore plugin

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -131,10 +131,13 @@
       }
     else
       options_params = {
-        'endpoint' => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}",
-        'user' => p('blobstore.agent.user'),
-        'password' => p('blobstore.agent.password')
+        'endpoint' => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}"
       }
+
+      if_p('blobstore.agent.user') do
+        options_params["user"] = p('blobstore.agent.user')
+        options_params["password"] = p('blobstore.agent.password')
+      end
     end
     blobstore_params['options'] = options_params
     params['cloud']['properties']['agent']['blobstore'] = blobstore_params

--- a/src/bosh_azure_cpi/bin/test-unit
+++ b/src/bosh_azure_cpi/bin/test-unit
@@ -18,7 +18,7 @@ case $key in
     ;;
     *)    # unknown option
     echo "Usage: ./test-unit [[-s|--spec] spec/unit/*] [-sb|--skip-ruby-check]"
-    break
+    exit 2
     ;;
 esac
 done

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -511,9 +511,9 @@ describe 'cpi.json.erb' do
   end
 
   context 'when parsing the agent property' do
-    context 'when using an s3 blobstore' do
-      let(:rendered_blobstore) { subject['cloud']['properties']['agent']['blobstore'] }
+    let(:rendered_blobstore) { subject['cloud']['properties']['agent']['blobstore'] }
 
+    context 'when using an s3 blobstore' do
       context 'when provided a minimal configuration' do
         before do
           manifest['properties']['blobstore'].merge!(
@@ -541,8 +541,6 @@ describe 'cpi.json.erb' do
     end
 
     context 'when using a local blobstore' do
-      let(:rendered_blobstore) { subject['cloud']['properties']['agent']['blobstore'] }
-
       context 'when provided a minimal configuration' do
         before do
           manifest['properties']['blobstore'].merge!(
@@ -570,6 +568,25 @@ describe 'cpi.json.erb' do
 
         it 'raises an error' do
           expect { rendered_blobstore }.to raise_error(/Can't find property 'blobstore.path'/)
+        end
+      end
+    end
+
+    context 'when using a dav blobstore' do
+      it 'renders agent user/password for accessing blobstore' do
+        expect(rendered_blobstore['options']['user']).to eq('agent')
+        expect(rendered_blobstore['options']['password']).to eq('agent-password')
+      end
+
+      context 'when enabling signed URLs' do
+        before do
+          manifest['properties']['blobstore']['agent'].delete('user')
+          manifest['properties']['blobstore']['agent'].delete('password')
+        end
+
+        it 'does not render agent user/password for accessing blobstore' do
+          expect(rendered_blobstore['options']['user']).to be_nil
+          expect(rendered_blobstore['options']['password']).to be_nil
         end
       end
     end


### PR DESCRIPTION
When signed URLs are enabled, no agent user/password should be specified in Director's deployment manifest for CPIs config.

This PR relates to previous work in:
- cloudfoundry/bosh#2327
- cloudfoundry/bosh-deployment#423
- cloudfoundry/docs-bosh#755
- cloudfoundry/bosh-davcli#12
- cloudfoundry/bosh-aws-cpi-release#118
- cloudfoundry/bosh-google-cpi-release#327
- cloudfoundry-incubator/bosh-alicloud-cpi-release#148
- cloudfoundry/bosh-openstack-cpi-release#242

Here we make the properties `blobstore.agent.{user,password}` optional.

**Worth to note**, since cloudfoundry/bosh-agent@b4ae2397 shipped in Agent v2.42.0 on November 2017, the `blobstore.options` (at the root of the Agent settings JSON) are not used anymore by the Bosh Agent. So nowadays that no more supported Stemcell ships with older Agents, the CPIs should not add those properties anymore to the Agent settings.

ERB test cases have been added to provide proper coverage for the new use-case. Then can be run with:
```
./src/bosh_azure_cpi/bin/test-unit --spec spec/unit/bosh_release
```

Co-Authored-By: @ansh-SAP