### PR TITLE
Update development.md with additional `chruby` setup info

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -47,9 +47,9 @@
     source ~/.profile
     ```
 
-1. Install ruby
+1. Install chruby
 
-    Please make sure you have installed ruby `2.7.3` before you start.
+   Please make sure you have installed `chruby` before you start.
 
     ```bash
     cd ~/workspace
@@ -60,6 +60,29 @@
       echo 'source /usr/local/share/chruby/chruby.sh' >> ~/.profile
     popd
     source ~/.profile
+    ```
+
+   _Note:_ The development scripts expect `chruby` to be located at `/usr/local/share/chruby`.
+   Installing `chruby` via other mechanisms than those shown above may require additional steps 
+   to make the installation compatible with the development scripts' expectations.
+   For example, to install `chruby` via `homebrew`, you could create a softlink 
+   from the brew-installed location to the script-expected location:
+
+    ```bash
+    brew install chruby
+    sudo ln -s '/opt/homebrew/opt/chruby/share/chruby' '/usr/local/share/chruby'
+    echo 'source /usr/local/share/chruby/chruby.sh' >> ~/.profile
+    source ~/.profile
+    ```
+
+1. Install ruby
+
+    Please make sure you have installed ruby `2.7.3` before you start.
+
+    _Note:_ The development scripts use `chruby` as the ruby version manager.
+
+    ```bash
+    cd ~/workspace
 
     wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz
     tar -xzvf ruby-install-0.6.1.tar.gz


### PR DESCRIPTION
Note: This repo's dev scripts impose specific constraints about the location at which `chruby` is installed (see [this script code](https://github.com/cloudfoundry/bosh-azure-cpi-release/blob/ca6886a8b43ffbe56a44b594ec2a73af745ab77d/src/bosh_azure_cpi/bin/check-ruby-version#L3-L5)). Those constraints were previously undocumented within [docs/development.md](https://github.com/cloudfoundry/bosh-azure-cpi-release/blob/master/docs/development.md). This PR makes them explicit.

---

- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage should keeps at 100%. 

  **_NOTE:_** This PR changes no code _or_ tests, just MD docs. So I'm assuming that the drop to `4182 / 4203 LOC (99.5%) covered` is due to some previous PR.

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  
  ...[verbose spec output omitted for brevity]...
  
  Top 10 slowest examples (2.16 seconds, 42.1% of total time):
    Bosh::AzureCloud::Helpers#flock for multiple processes with exclusive lock the processes should get the lock sequentially and then call the block
      1.02 seconds ./spec/unit/helpers_spec.rb:930
    Bosh::AzureCloud::Helpers#flock for multiple processes with share lock the processes should get the lock in parallel and then call the block
      0.51163 seconds ./spec/unit/helpers_spec.rb:959
    Bosh::AzureCloud::TelemetryEventList#format_data_for_wire_server should return with right value
      0.14532 seconds ./spec/unit/telemetry/telemetry_event_list_spec.rb:47
    Bosh::AzureCloud::Helpers#flock for multiple processes with exclusive but no block lock only the process gets the lock and calls the block, the other process should return directly
      0.11444 seconds ./spec/unit/helpers_spec.rb:987
    Bosh::AzureCloud::BlobManager#create_page_blob when empty page blob should not call put_blob_pages
      0.07435 seconds ./spec/unit/blob_manager_spec.rb:209
    Bosh::AzureCloud::BlobManager#create_empty_page_blob when container not exists when other one created the container should use the created container
      0.05982 seconds ./spec/unit/blob_manager_spec.rb:288
    Bosh::AzureCloud::BlobManager#create_page_blob when normal page blob when uploading page blob succeeds raise no error
      0.05972 seconds ./spec/unit/blob_manager_spec.rb:160
    Bosh::AzureCloud::BlobManager#get_blob_properties when storage account does not exist should raise error
      0.05947 seconds ./spec/unit/blob_manager_spec.rb:404
    Bosh::AzureCloud::BlobManager#get_blob_size_in_bytes gets the size of the blob
      0.05927 seconds ./spec/unit/blob_manager_spec.rb:124
    Bosh::AzureCloud::BlobManager#create_vhd_page_blob when creating vhd page blob failed page blob created page blob should be deleted
      0.05921 seconds ./spec/unit/blob_manager_spec.rb:375  

  Top 10 slowest example groups:
    Bosh::AzureCloud::BlobManager
      0.04412 seconds average (1.76 seconds / 40 examples) ./spec/unit/blob_manager_spec.rb:4
    Bosh::AzureCloud::TelemetryEventList
      0.0365 seconds average (0.14601 seconds / 4 examples) ./spec/unit/telemetry/telemetry_event_list_spec.rb:5
    Bosh::AzureCloud::VMManager
      0.02061 seconds average (0.06184 seconds / 3 examples) ./spec/unit/vm_manager/create/use_config_disk_spec.rb:9
    Bosh::AzureCloud::Helpers
      0.02022 seconds average (1.68 seconds / 83 examples) ./spec/unit/helpers_spec.rb:5
    Bosh::AzureCloud::AzureClient
      0.00945 seconds average (0.0189 seconds / 2 examples) ./spec/unit/azure_client/update_tags_of_storage_account_spec.rb:8
    Bosh::AzureCloud::CPILogger
      0.00873 seconds average (0.00873 seconds / 1 example) ./spec/unit/logger_spec.rb:5
    Bosh::AzureCloud::AzureClient
      0.00624 seconds average (0.01871 seconds / 3 examples) ./spec/unit/azure_client/create_resource_group_spec.rb:8
    Bosh::AzureCloud::AzureClient
      0.00581 seconds average (0.01162 seconds / 2 examples) ./spec/unit/azure_client/request_headers_spec.rb:8
    Bosh::AzureCloud::AzureClient
      0.00469 seconds average (0.02343 seconds / 5 examples) ./spec/unit/azure_client/attach_disk_to_virtual_machine_spec.rb:8
    Bosh::AzureCloud::AzureClient
      0.00444 seconds average (0.0311 seconds / 7 examples) ./spec/unit/azure_client/create_storage_account_spec.rb:8  

  Finished in 5.12 seconds (files took 1.59 seconds to load)
  972 examples, 0 failures  

  Coverage report generated for RSpec to /Users/justinw/go/src/github.com/cloudfoundry/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage. 4182 / 4203 LOC (99.5%) covered.
  ~/go/src/github.com/cloudfoundry/bosh-azure-cpi-release/src/bosh_azure_cpi
  ```

  NOTE: Please see how to setup dev environment and run unit tests in docs/development.md.

### Changelog

* Updated development.md with additional `chruby` setup info
