### PR TITLE
Issue 644 Support for multiple AGWs/LBs and named backend pools

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
@@ -2,14 +2,16 @@
 
 module Bosh::AzureCloud
   class LoadBalancerConfig
-    attr_reader :name, :resource_group_name
-    def initialize(resource_group_name, name)
+    attr_reader :name, :resource_group_name, :backend_pool_name
+
+    def initialize(resource_group_name, name, backend_pool_name = nil)
       @resource_group_name = resource_group_name
       @name = name
+      @backend_pool_name = backend_pool_name
     end
 
     def to_s
-      "name: #{@name}, resource_group_name: #{@resource_group_name}"
+      "name: #{@name}, resource_group_name: #{@resource_group_name}, backend_pool_name: #{@backend_pool_name}"
     end
   end
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
@@ -14,16 +14,16 @@ module Bosh::AzureCloud
   end
 
   class ApplicationGatewayConfig
-    # TODO: issue-644: multi-BEPool-AGW: Add support for explicitly specified BEPool name.
-    attr_reader :name, :resource_group_name
+    attr_reader :name, :resource_group_name, :backend_pool_name
 
-    def initialize(resource_group_name, name)
+    def initialize(resource_group_name, name, backend_pool_name = nil)
       @resource_group_name = resource_group_name
       @name = name
+      @backend_pool_name = backend_pool_name
     end
 
     def to_s
-      "name: #{@name}, resource_group_name: #{@resource_group_name}"
+      "name: #{@name}, resource_group_name: #{@resource_group_name}, backend_pool_name: #{@backend_pool_name}"
     end
   end
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
@@ -13,6 +13,20 @@ module Bosh::AzureCloud
     end
   end
 
+  class ApplicationGatewayConfig
+    # TODO: issue-644: multi-BEPool-AGW: Add support for explicitly specified BEPool name.
+    attr_reader :name, :resource_group_name
+
+    def initialize(resource_group_name, name)
+      @resource_group_name = resource_group_name
+      @name = name
+    end
+
+    def to_s
+      "name: #{@name}, resource_group_name: #{@resource_group_name}"
+    end
+  end
+
   class AvailabilitySetConfig
     attr_reader :name
     attr_reader :platform_update_domain_count, :platform_fault_domain_count

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
@@ -115,14 +115,17 @@ module Bosh::AzureCloud
         if lbc.is_a?(Hash)
           load_balancer_names = lbc[NAME_KEY]
           resource_group_name = lbc[RESOURCE_GROUP_NAME_KEY]
+          backend_pool_name = lbc[BACKEND_POOL_NAME_KEY]
         else
           load_balancer_names = lbc
           resource_group_name = nil
+          backend_pool_name = nil
         end
         String(load_balancer_names).split(',').map do |load_balancer_name|
           Bosh::AzureCloud::LoadBalancerConfig.new(
             resource_group_name || global_azure_config.resource_group_name,
-            load_balancer_name
+            load_balancer_name,
+            backend_pool_name
           )
         end
       end

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
@@ -27,6 +27,7 @@ module Bosh::AzureCloud
     AVAILABILITY_SET_KEY = 'availability_set'
     LOAD_BALANCER_KEY = 'load_balancer'
     APPLICATION_GATEWAY_KEY = 'application_gateway'
+    BACKEND_POOL_NAME_KEY = 'backend_pool_name'
     RESOURCE_GROUP_NAME_KEY = 'resource_group_name'
     NAME_KEY = 'name'
 
@@ -141,16 +142,19 @@ module Bosh::AzureCloud
         if agwc.is_a?(Hash)
           application_gateway_names = agwc[NAME_KEY]
           resource_group_name = agwc[RESOURCE_GROUP_NAME_KEY]
+          backend_pool_name = agwc[BACKEND_POOL_NAME_KEY]
         else
           application_gateway_names = agwc
           resource_group_name = nil
+          backend_pool_name = nil
         end
         String(application_gateway_names).split(',').map do |application_gateway_name|
           Bosh::AzureCloud::ApplicationGatewayConfig.new(
             # NOTE: It is OK for the resource_group_name to be `nil` here. The nil will be defaulted elsewhere (if needed). And leaving it nil makes the specs simpler.
             # resource_group_name || global_azure_config.resource_group_name,
             resource_group_name,
-            application_gateway_name
+            application_gateway_name,
+            backend_pool_name
           )
         end
       end

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
@@ -154,7 +154,6 @@ module Bosh::AzureCloud
         String(application_gateway_names).split(',').map do |application_gateway_name|
           Bosh::AzureCloud::ApplicationGatewayConfig.new(
             # NOTE: It is OK for the resource_group_name to be `nil` here. The nil will be defaulted elsewhere (if needed). And leaving it nil makes the specs simpler.
-            # resource_group_name || global_azure_config.resource_group_name,
             resource_group_name,
             application_gateway_name,
             backend_pool_name

--- a/src/bosh_azure_cpi/lib/cloud/azure/network/network_configurator.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/network/network_configurator.rb
@@ -9,7 +9,7 @@ module Bosh::AzureCloud
   # VM can have multiple network interfaces attached to it.
   # The VM size determines the number of NICs that you can create for a VM, please refer to
   # https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-sizes/ for the max number of NICs for different VM size.
-  # When there are multiple netowrks, you must have and only have 1 primary network specified. @networks[0] will be picked as the primary network.
+  # When there are multiple networks, you must have and only have 1 primary network specified. @networks[0] will be picked as the primary network.
   #
 
   class NetworkConfigurator
@@ -64,6 +64,7 @@ module Bosh::AzureCloud
         #
         unless network.nil?
           if network.has_default_gateway?
+            # make it the first network, so that it is the Primary
             @networks.insert(0, network)
           else
             @networks.push(network)

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -1653,13 +1653,15 @@ module Bosh::AzureCloud
         application_gateway[:tags] = result['tags']
 
         properties = result['properties']
-        # TODO: issue-644: multi-BEPool-AGW: Review: Already supports multiple ApplicationGateway Backend Address Pools?
         # see: https://docs.microsoft.com/en-us/rest/api/application-gateway/application-gateways/get#applicationgatewaybackendaddresspool
         backend = properties['backendAddressPools']
         application_gateway[:backend_address_pools] = []
         backend.each do |backend_ip|
           ip = {}
-          ip[:id] = backend_ip['id']
+          ip[:name]                      = backend_ip['name']
+          ip[:id]                        = backend_ip['id']
+          ip[:provisioning_state]        = backend_ip['properties']['provisioningState']
+          ip[:backend_ip_configurations] = backend_ip['properties']['backendIPConfigurations']
           application_gateway[:backend_address_pools].push(ip)
         end
       end

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -302,6 +302,7 @@ module Bosh::AzureCloud
         network_interfaces_params.push(
           'id' => network_interface[:id],
           'properties' => {
+            # NOTE: The first NIC is the Primary/Gateway network. See: `Bosh::AzureCloud::NetworkConfigurator.initialize`.
             'primary' => index.zero?
           }
         )

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_network.rb
@@ -182,6 +182,7 @@ module Bosh::AzureCloud
           enable_accelerated_networking: accelerated_networking
         }
         nic_params[:subnet] = _get_network_subnet(network)
+        # NOTE: The first NIC is the Primary/Gateway network. See: `Bosh::AzureCloud::NetworkConfigurator.initialize`.
         if index.zero?
           nic_params[:public_ip] = public_ip
           nic_params[:tags] = primary_nic_tags

--- a/src/bosh_azure_cpi/spec/integration/resources/application_gateway_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/resources/application_gateway_spec.rb
@@ -7,7 +7,7 @@ describe Bosh::AzureCloud::Cloud do
     @application_gateway_name = ENV.fetch('BOSH_AZURE_APPLICATION_GATEWAY_NAME')
   end
 
-  context 'when application_gateway is specified in resource pool' do
+  context 'when single application_gateway is specified in resource pool' do
     let(:network_spec) do
       {
         'network_a' => {

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
@@ -270,36 +270,6 @@ describe Bosh::AzureCloud::AzureClient do
       end
 
       context 'with load balancer' do
-        let(:nic_params) do
-          {
-            name: nic_name,
-            location: 'fake-location',
-            ipconfig_name: 'fake-ipconfig-name',
-            subnet: { id: subnet[:id] },
-            tags: {},
-            enable_ip_forwarding: false,
-            enable_accelerated_networking: false,
-            private_ip: '10.0.0.100',
-            dns_servers: ['168.63.129.16'],
-            public_ip: { id: 'fake-public-id' },
-            network_security_group: { id: nsg_id },
-            application_security_groups: [],
-            load_balancers: [{
-              backend_address_pools: [
-                {
-                  id: 'fake-id'
-                }
-              ],
-              frontend_ip_configurations: [
-                {
-                  inbound_nat_rules: [{}]
-                }
-              ]
-            }],
-            application_gateways: nil
-          }
-        end
-
         let(:request_body) do
           {
             name: nic_params[:name],
@@ -320,12 +290,8 @@ describe Bosh::AzureCloud::AzureClient do
                   subnet: {
                     id: subnet[:id]
                   },
-                  loadBalancerBackendAddressPools: [
-                    {
-                      id: 'fake-id'
-                    }
-                  ],
-                  loadBalancerInboundNatRules: [{}]
+                  loadBalancerBackendAddressPools: nic_params[:load_balancers].map { |lb| { id: lb[:backend_address_pools][0][:id] } },
+                  loadBalancerInboundNatRules: nic_params[:load_balancers].flat_map { |lb| lb[:frontend_ip_configurations][0][:inbound_nat_rules] }.compact
                 }
               }],
               dnsSettings: {
@@ -335,7 +301,7 @@ describe Bosh::AzureCloud::AzureClient do
           }
         end
 
-        it 'should create a network interface without error' do
+        before do
           stub_request(:post, token_uri).to_return(
             status: 200,
             body: {
@@ -358,39 +324,325 @@ describe Bosh::AzureCloud::AzureClient do
             body: '{"status":"Succeeded"}',
             headers: {}
           )
-
-          expect do
-            azure_client.create_network_interface(resource_group, nic_params)
-          end.not_to raise_error
         end
 
-        context 'with multiple backend pools' do
-          # TODO: issue-644: multi-BEPool-LB: add unit tests for multi-pool LBs
-          it 'should create a network interface without error'
+        context 'with single load balancer' do
+          context 'with single backend pool' do
+            let(:nic_params) do
+              {
+                name: nic_name,
+                location: 'fake-location',
+                ipconfig_name: 'fake-ipconfig-name',
+                subnet: { id: subnet[:id] },
+                tags: {},
+                enable_ip_forwarding: false,
+                enable_accelerated_networking: false,
+                private_ip: '10.0.0.100',
+                dns_servers: ['168.63.129.16'],
+                public_ip: { id: 'fake-public-id' },
+                network_security_group: { id: nsg_id },
+                application_security_groups: [],
+                load_balancers: [{
+                  backend_address_pools: [
+                    {
+                      name: 'fake-lb-pool-name',
+                      id: 'fake-lb-pool-id'
+                    }
+                  ],
+                  frontend_ip_configurations: [
+                    {
+                      inbound_nat_rules: [{}]
+                    }
+                  ]
+                }],
+                application_gateways: nil
+              }
+            end
 
-          context 'when backend_pool_name is specified' do
-            # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
-            it 'should use the specified backend_pool'
+            it 'should create a network interface without error' do
+              expect do
+                azure_client.create_network_interface(resource_group, nic_params)
+              end.not_to raise_error
+            end
           end
 
-          context 'when an invalid backend_pool_name is specified' do
-            # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
-            it 'should raise an error'
+          context 'with multiple backend pools' do
+            context 'when backend_pool_name is not specified' do
+              let(:nic_params) do
+                {
+                  name: nic_name,
+                  location: 'fake-location',
+                  ipconfig_name: 'fake-ipconfig-name',
+                  subnet: { id: subnet[:id] },
+                  tags: {},
+                  enable_ip_forwarding: false,
+                  enable_accelerated_networking: false,
+                  private_ip: '10.0.0.100',
+                  dns_servers: ['168.63.129.16'],
+                  public_ip: { id: 'fake-public-id' },
+                  network_security_group: { id: nsg_id },
+                  application_security_groups: [],
+                  load_balancers: [{
+                    backend_address_pools: [
+                      {
+                        name: 'fake-lb-pool-name',
+                        id: 'fake-lb-pool-id'
+                      },
+                      {
+                        name: 'fake-lb-pool2-name',
+                        id: 'fake-lb-pool2-id'
+                      }
+                    ],
+                    frontend_ip_configurations: [
+                      {
+                        inbound_nat_rules: [{}]
+                      }
+                    ]
+                  }],
+                  application_gateways: nil
+                }
+              end
+
+              it 'should use the default backend_pools' do
+                expect do
+                  azure_client.create_network_interface(resource_group, nic_params)
+                end.not_to raise_error
+              end
+            end
+
+            context 'when backend_pool_name is specified' do
+              let(:nic_params) do
+                {
+                  name: nic_name,
+                  location: 'fake-location',
+                  ipconfig_name: 'fake-ipconfig-name',
+                  subnet: { id: subnet[:id] },
+                  tags: {},
+                  enable_ip_forwarding: false,
+                  enable_accelerated_networking: false,
+                  private_ip: '10.0.0.100',
+                  dns_servers: ['168.63.129.16'],
+                  public_ip: { id: 'fake-public-id' },
+                  network_security_group: { id: nsg_id },
+                  application_security_groups: [],
+                  # NOTE: This data would normally be created by the `VMManager._get_load_balancers` method,
+                  # which would remove all but the `vm_props`-configured pool from the list.
+                  load_balancers: [{
+                    backend_address_pools: [
+                      # {
+                      #   name: 'fake-lb-pool-name',
+                      #   id: 'fake-lb-pool-id'
+                      # },
+                      {
+                        name: 'fake-lb-pool2-name',
+                        id: 'fake-lb-pool2-id'
+                      }
+                    ],
+                    frontend_ip_configurations: [
+                      {
+                        inbound_nat_rules: [{}]
+                      }
+                    ]
+                  }],
+                  application_gateways: nil
+                }
+              end
+
+              it 'should use the specified backend_pools' do
+                expect do
+                  azure_client.create_network_interface(resource_group, nic_params)
+                end.not_to raise_error
+              end
+            end
           end
+
+          # NOTE: This should never happen, since an error would be raised earlier (preventing `azure_client.create_network_interface` from being called)
+          # context 'when an invalid backend_pool_name is specified' do
+          #   it 'should never happen'
+          # end
         end
-      end
 
-      context 'with multiple load balancers' do # rubocop:disable RSpec/RepeatedExampleGroupBody
-        # TODO: issue-644: multi-LB: add unit tests for multi-LBs
-        it 'should create a network interface without error'
+        context 'with multiple load balancers' do
+          context 'with single backend pool' do
+            let(:nic_params) do
+              {
+                name: nic_name,
+                location: 'fake-location',
+                ipconfig_name: 'fake-ipconfig-name',
+                subnet: { id: subnet[:id] },
+                tags: {},
+                enable_ip_forwarding: false,
+                enable_accelerated_networking: false,
+                private_ip: '10.0.0.100',
+                dns_servers: ['168.63.129.16'],
+                public_ip: { id: 'fake-public-id' },
+                network_security_group: { id: nsg_id },
+                application_security_groups: [],
+                load_balancers: [
+                  {
+                    backend_address_pools: [
+                      {
+                        name: 'fake-lb-pool-name',
+                        id: 'fake-lb-pool-id'
+                      }
+                    ],
+                    frontend_ip_configurations: [
+                      {
+                        inbound_nat_rules: [{}]
+                      }
+                    ]
+                  },
+                  {
+                    backend_address_pools: [
+                      {
+                        name: 'fake-lb2-pool-1-name',
+                        id: 'fake-lb2-pool-1-id'
+                      }
+                    ],
+                    frontend_ip_configurations: [
+                      {
+                        inbound_nat_rules: [{}]
+                      }
+                    ]
+                  }
+                ],
+                application_gateways: nil
+              }
+            end
 
-        context 'with multiple backend pools' do
-          # TODO: issue-644: multi-BEPool-LB: add unit tests for multi-pool LBs
-          it 'should create a network interface without error'
+            it 'should create a network interface without error' do
+              expect do
+                azure_client.create_network_interface(resource_group, nic_params)
+              end.not_to raise_error
+            end
+          end
 
-          context 'when backend_pool_name is specified' do
-            # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
-            it 'should use the specified backend_pool'
+          context 'with multiple backend pools' do
+            context 'when backend_pool_name is not specified' do
+              let(:nic_params) do
+                {
+                  name: nic_name,
+                  location: 'fake-location',
+                  ipconfig_name: 'fake-ipconfig-name',
+                  subnet: { id: subnet[:id] },
+                  tags: {},
+                  enable_ip_forwarding: false,
+                  enable_accelerated_networking: false,
+                  private_ip: '10.0.0.100',
+                  dns_servers: ['168.63.129.16'],
+                  public_ip: { id: 'fake-public-id' },
+                  network_security_group: { id: nsg_id },
+                  application_security_groups: [],
+                  load_balancers: [
+                    {
+                      backend_address_pools: [
+                        {
+                          name: 'fake-lb-pool-name',
+                          id: 'fake-lb-pool-id'
+                        },
+                        {
+                          name: 'fake-lb-pool2-name',
+                          id: 'fake-lb-pool2-id'
+                        }
+                      ],
+                      frontend_ip_configurations: [
+                        {
+                          inbound_nat_rules: [{}]
+                        }
+                      ]
+                    },
+                    {
+                      backend_address_pools: [
+                        {
+                          name: 'fake-lb2-pool-1-name',
+                          id: 'fake-lb2-pool-1-id'
+                        },
+                        {
+                          name: 'fake-lb2-pool-2-name',
+                          id: 'fake-lb2-pool-2-id'
+                        }
+                      ],
+                      frontend_ip_configurations: [
+                        {
+                          inbound_nat_rules: [{}]
+                        }
+                      ]
+                    }
+                  ],
+                  application_gateways: nil
+                }
+              end
+
+              it 'should use the default backend_pools' do
+                expect do
+                  azure_client.create_network_interface(resource_group, nic_params)
+                end.not_to raise_error
+              end
+            end
+
+            context 'when backend_pool_name is specified' do
+              let(:nic_params) do
+                {
+                  name: nic_name,
+                  location: 'fake-location',
+                  ipconfig_name: 'fake-ipconfig-name',
+                  subnet: { id: subnet[:id] },
+                  tags: {},
+                  enable_ip_forwarding: false,
+                  enable_accelerated_networking: false,
+                  private_ip: '10.0.0.100',
+                  dns_servers: ['168.63.129.16'],
+                  public_ip: { id: 'fake-public-id' },
+                  network_security_group: { id: nsg_id },
+                  application_security_groups: [],
+                  # NOTE: This data would normally be created by the `VMManager._get_load_balancers` method,
+                  # which would remove all but the `vm_props`-configured pools from the list.
+                  load_balancers: [
+                    {
+                      backend_address_pools: [
+                        # {
+                        #   name: 'fake-lb-pool-name',
+                        #   id: 'fake-lb-pool-id'
+                        # },
+                        {
+                          name: 'fake-lb-pool2-name',
+                          id: 'fake-lb-pool2-id'
+                        }
+                      ],
+                      frontend_ip_configurations: [
+                        {
+                          inbound_nat_rules: [{}]
+                        }
+                      ]
+                    },
+                    {
+                      backend_address_pools: [
+                        # {
+                        #   name: 'fake-lb2-pool-1-name',
+                        #   id: 'fake-lb2-pool-1-id'
+                        # },
+                        {
+                          name: 'fake-lb2-pool-2-name',
+                          id: 'fake-lb2-pool-2-id'
+                        }
+                      ],
+                      frontend_ip_configurations: [
+                        {
+                          inbound_nat_rules: [{}]
+                        }
+                      ]
+                    }
+                  ],
+                  application_gateways: nil
+                }
+              end
+
+              it 'should use the specified backend_pools' do
+                expect do
+                  azure_client.create_network_interface(resource_group, nic_params)
+                end.not_to raise_error
+              end
+            end
           end
         end
       end
@@ -481,32 +733,7 @@ describe Bosh::AzureCloud::AzureClient do
         end
       end
 
-      # NOTE: issue-644: unit tests for single-AGW, single-pool
       context 'with application gateway' do
-        let(:nic_params) do
-          {
-            name: nic_name,
-            location: 'fake-location',
-            ipconfig_name: 'fake-ipconfig-name',
-            subnet: { id: subnet[:id] },
-            tags: {},
-            enable_ip_forwarding: false,
-            enable_accelerated_networking: false,
-            private_ip: '10.0.0.100',
-            dns_servers: ['168.63.129.16'],
-            public_ip: { id: 'fake-public-id' },
-            network_security_group: { id: nsg_id },
-            application_security_groups: [],
-            load_balancers: nil,
-            application_gateways: [{
-              backend_address_pools: [
-                {
-                  id: 'fake-id-2'
-                }
-              ]
-            }]
-          }
-        end
         let(:request_body) do
           {
             name: nic_params[:name],
@@ -527,11 +754,7 @@ describe Bosh::AzureCloud::AzureClient do
                   subnet: {
                     id: subnet[:id]
                   },
-                  applicationGatewayBackendAddressPools: [
-                    {
-                      id: 'fake-id-2'
-                    }
-                  ]
+                  applicationGatewayBackendAddressPools: nic_params[:application_gateways].map { |agw| { id: agw[:backend_address_pools][0][:id] } }
                 }
               }],
               dnsSettings: {
@@ -541,7 +764,7 @@ describe Bosh::AzureCloud::AzureClient do
           }
         end
 
-        it 'should create a network interface without error' do
+        before do
           stub_request(:post, token_uri).to_return(
             status: 200,
             body: {
@@ -564,39 +787,284 @@ describe Bosh::AzureCloud::AzureClient do
             body: '{"status":"Succeeded"}',
             headers: {}
           )
-
-          expect do
-            azure_client.create_network_interface(resource_group, nic_params)
-          end.not_to raise_error
         end
 
-        context 'with multiple backend pools' do
-          # TODO: issue-644: multi-BEPool-AGW: add unit tests for multi-pool AGWs
-          it 'should create a network interface without error'
+        context 'with single application gateway' do
+          context 'with single backend pool' do
+            let(:nic_params) do
+              {
+                name: nic_name,
+                location: 'fake-location',
+                ipconfig_name: 'fake-ipconfig-name',
+                subnet: { id: subnet[:id] },
+                tags: {},
+                enable_ip_forwarding: false,
+                enable_accelerated_networking: false,
+                private_ip: '10.0.0.100',
+                dns_servers: ['168.63.129.16'],
+                public_ip: { id: 'fake-public-id' },
+                network_security_group: { id: nsg_id },
+                application_security_groups: [],
+                load_balancers: nil,
+                application_gateways: [{
+                  backend_address_pools: [
+                    {
+                      name: 'fake-agw-pool-name',
+                      id: 'fake-agw-pool-id'
+                    }
+                  ]
+                }]
+              }
+            end
 
-          context 'when backend_pool_name is specified' do
-            # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
-            it 'should use the specified backend_pool'
+            it 'should create a network interface without error' do
+              expect do
+                azure_client.create_network_interface(resource_group, nic_params)
+              end.not_to raise_error
+            end
           end
 
-          context 'when an invalid backend_pool_name is specified' do
-            # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
-            it 'should raise an error'
+          context 'with multiple backend pools' do
+            context 'when backend_pool_name is not specified' do
+              let(:nic_params) do
+                {
+                  name: nic_name,
+                  location: 'fake-location',
+                  ipconfig_name: 'fake-ipconfig-name',
+                  subnet: { id: subnet[:id] },
+                  tags: {},
+                  enable_ip_forwarding: false,
+                  enable_accelerated_networking: false,
+                  private_ip: '10.0.0.100',
+                  dns_servers: ['168.63.129.16'],
+                  public_ip: { id: 'fake-public-id' },
+                  network_security_group: { id: nsg_id },
+                  application_security_groups: [],
+                  load_balancers: nil,
+                  application_gateways: [
+                    {
+                      backend_address_pools: [
+                        {
+                          name: 'fake-agw-pool-name',
+                          id: 'fake-agw-pool-id'
+                        },
+                        {
+                          name: 'fake-agw-pool2-name',
+                          id: 'fake-agw-pool2-id'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              end
+
+              it 'should use the default backend_pools' do
+                expect do
+                  azure_client.create_network_interface(resource_group, nic_params)
+                end.not_to raise_error
+              end
+            end
+
+            context 'when backend_pool_name is specified' do
+              let(:nic_params) do
+                {
+                  name: nic_name,
+                  location: 'fake-location',
+                  ipconfig_name: 'fake-ipconfig-name',
+                  subnet: { id: subnet[:id] },
+                  tags: {},
+                  enable_ip_forwarding: false,
+                  enable_accelerated_networking: false,
+                  private_ip: '10.0.0.100',
+                  dns_servers: ['168.63.129.16'],
+                  public_ip: { id: 'fake-public-id' },
+                  network_security_group: { id: nsg_id },
+                  application_security_groups: [],
+                  load_balancers: nil,
+                  # NOTE: This data would normally be created by the `VMManager._get_application_gateways` method,
+                  # which would remove all but the `vm_props`-configured pool from the list.
+                  application_gateways: [
+                    {
+                      backend_address_pools: [
+                        # {
+                        #   name: 'fake-agw-pool-name',
+                        #   id: 'fake-agw-pool-id'
+                        # },
+                        {
+                          name: 'fake-agw-pool2-name',
+                          id: 'fake-agw-pool2-id'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              end
+
+              it 'should use the specified backend_pools' do
+                expect do
+                  azure_client.create_network_interface(resource_group, nic_params)
+                end.not_to raise_error
+              end
+            end
           end
+
+          # NOTE: This should never happen, since an error would be raised earlier (preventing `azure_client.create_network_interface` from being called)
+          # context 'when an invalid backend_pool_name is specified' do
+          #   it 'should never happen'
+          # end
         end
-      end
 
-      context 'with multiple application gateways' do # rubocop:disable RSpec/RepeatedExampleGroupBody
-        # TODO: issue-644: multi-AGW: add unit tests for multi-AGWs
-        it 'should create a network interface without error'
+        context 'with multiple application gateways' do
+          context 'with single backend pool' do
+            let(:nic_params) do
+              {
+                name: nic_name,
+                location: 'fake-location',
+                ipconfig_name: 'fake-ipconfig-name',
+                subnet: { id: subnet[:id] },
+                tags: {},
+                enable_ip_forwarding: false,
+                enable_accelerated_networking: false,
+                private_ip: '10.0.0.100',
+                dns_servers: ['168.63.129.16'],
+                public_ip: { id: 'fake-public-id' },
+                network_security_group: { id: nsg_id },
+                application_security_groups: [],
+                load_balancers: nil,
+                application_gateways: [
+                  {
+                    backend_address_pools: [
+                      {
+                        name: 'fake-agw-pool-name',
+                        id: 'fake-agw-pool-id'
+                      }
+                    ]
+                  },
+                  {
+                    backend_address_pools: [
+                      {
+                        name: 'fake-agw2-pool-1-name',
+                        id: 'fake-agw2-pool-1-id'
+                      }
+                    ]
+                  }
+                ]
+              }
+            end
 
-        context 'with multiple backend pools' do
-          # TODO: issue-644: multi-BEPool-AGW: add unit tests for multi-pool AGWs
-          it 'should create a network interface without error'
+            it 'should create a network interface without error' do
+              expect do
+                azure_client.create_network_interface(resource_group, nic_params)
+              end.not_to raise_error
+            end
+          end
 
-          context 'when backend_pool_name is specified' do
-            # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
-            it 'should use the specified backend_pool'
+          context 'with multiple backend pools' do
+            context 'when backend_pool_name is not specified' do
+              let(:nic_params) do
+                {
+                  name: nic_name,
+                  location: 'fake-location',
+                  ipconfig_name: 'fake-ipconfig-name',
+                  subnet: { id: subnet[:id] },
+                  tags: {},
+                  enable_ip_forwarding: false,
+                  enable_accelerated_networking: false,
+                  private_ip: '10.0.0.100',
+                  dns_servers: ['168.63.129.16'],
+                  public_ip: { id: 'fake-public-id' },
+                  network_security_group: { id: nsg_id },
+                  application_security_groups: [],
+                  load_balancers: nil,
+                  application_gateways: [
+                    {
+                      backend_address_pools: [
+                        {
+                          name: 'fake-agw-pool-name',
+                          id: 'fake-agw-pool-id'
+                        },
+                        {
+                          name: 'fake-agw-pool2-name',
+                          id: 'fake-agw-pool2-id'
+                        }
+                      ]
+                    },
+                    {
+                      backend_address_pools: [
+                        {
+                          name: 'fake-agw2-pool-1-name',
+                          id: 'fake-agw2-pool-1-id'
+                        },
+                        {
+                          name: 'fake-agw2-pool-2-name',
+                          id: 'fake-agw2-pool-2-id'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              end
+
+              it 'should use the default backend_pools' do
+                expect do
+                  azure_client.create_network_interface(resource_group, nic_params)
+                end.not_to raise_error
+              end
+            end
+
+            context 'when backend_pool_name is specified' do
+              let(:nic_params) do
+                {
+                  name: nic_name,
+                  location: 'fake-location',
+                  ipconfig_name: 'fake-ipconfig-name',
+                  subnet: { id: subnet[:id] },
+                  tags: {},
+                  enable_ip_forwarding: false,
+                  enable_accelerated_networking: false,
+                  private_ip: '10.0.0.100',
+                  dns_servers: ['168.63.129.16'],
+                  public_ip: { id: 'fake-public-id' },
+                  network_security_group: { id: nsg_id },
+                  application_security_groups: [],
+                  load_balancers: nil,
+                  # NOTE: This data would normally be created by the `VMManager._get_application_gateways` method,
+                  # which would remove all but the `vm_props`-configured pools from the list.
+                  application_gateways: [
+                    {
+                      backend_address_pools: [
+                        # {
+                        #   name: 'fake-agw-pool-name',
+                        #   id: 'fake-agw-pool-id'
+                        # },
+                        {
+                          name: 'fake-agw-pool2-name',
+                          id: 'fake-agw-pool2-id'
+                        }
+                      ]
+                    },
+                    {
+                      backend_address_pools: [
+                        # {
+                        #   name: 'fake-agw2-pool-1-name',
+                        #   id: 'fake-agw2-pool-1-id'
+                        # },
+                        {
+                          name: 'fake-agw2-pool-2-name',
+                          id: 'fake-agw2-pool-2-id'
+                        }
+                      ]
+                    }
+                  ]
+                }
+              end
+
+              it 'should use the specified backend_pools' do
+                expect do
+                  azure_client.create_network_interface(resource_group, nic_params)
+                end.not_to raise_error
+              end
+            end
           end
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
@@ -55,7 +55,7 @@ describe Bosh::AzureCloud::AzureClient do
             public_ip: { id: 'fake-public-id' },
             network_security_group: { id: nsg_id },
             application_security_groups: [],
-            load_balancer: nil,
+            load_balancers: nil,
             application_gateway: nil
           }
         end
@@ -130,7 +130,7 @@ describe Bosh::AzureCloud::AzureClient do
             enable_accelerated_networking: false,
             network_security_group: { id: nsg_id },
             application_security_groups: [],
-            load_balancer: nil,
+            load_balancers: nil,
             application_gateway: nil
           }
         end
@@ -208,7 +208,7 @@ describe Bosh::AzureCloud::AzureClient do
             public_ip: { id: 'fake-public-id' },
             network_security_group: nil,
             application_security_groups: [],
-            load_balancer: nil,
+            load_balancers: nil,
             application_gateway: nil
           }
         end
@@ -284,7 +284,7 @@ describe Bosh::AzureCloud::AzureClient do
             public_ip: { id: 'fake-public-id' },
             network_security_group: { id: nsg_id },
             application_security_groups: [],
-            load_balancer: [{
+            load_balancers: [{
               backend_address_pools: [
                 {
                   id: 'fake-id'
@@ -380,7 +380,7 @@ describe Bosh::AzureCloud::AzureClient do
             public_ip: { id: 'fake-public-id' },
             network_security_group: { id: nsg_id },
             application_security_groups: [{ id: 'fake-asg-id-1' }, { id: 'fake-asg-id-2' }],
-            load_balancer: nil,
+            load_balancers: nil,
             application_gateway: nil
           }
         end
@@ -466,7 +466,7 @@ describe Bosh::AzureCloud::AzureClient do
             public_ip: { id: 'fake-public-id' },
             network_security_group: { id: nsg_id },
             application_security_groups: [],
-            load_balancer: nil,
+            load_balancers: nil,
             application_gateway: {
               backend_address_pools: [
                 {

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
@@ -363,6 +363,36 @@ describe Bosh::AzureCloud::AzureClient do
             azure_client.create_network_interface(resource_group, nic_params)
           end.not_to raise_error
         end
+
+        context 'with multiple backend pools' do
+          # TODO: issue-644: multi-BEPool-LB: add unit tests for multi-pool LBs
+          it 'should create a network interface without error'
+
+          context 'when backend_pool_name is specified' do
+            # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
+            it 'should use the specified backend_pool'
+          end
+
+          context 'when an invalid backend_pool_name is specified' do
+            # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
+            it 'should raise an error'
+          end
+        end
+      end
+
+      context 'with multiple load balancers' do # rubocop:disable RSpec/RepeatedExampleGroupBody
+        # TODO: issue-644: multi-LB: add unit tests for multi-LBs
+        it 'should create a network interface without error'
+
+        context 'with multiple backend pools' do
+          # TODO: issue-644: multi-BEPool-LB: add unit tests for multi-pool LBs
+          it 'should create a network interface without error'
+
+          context 'when backend_pool_name is specified' do
+            # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
+            it 'should use the specified backend_pool'
+          end
+        end
       end
 
       context 'with application security groups' do
@@ -556,7 +586,7 @@ describe Bosh::AzureCloud::AzureClient do
         end
       end
 
-      context 'with multiple application gateways' do
+      context 'with multiple application gateways' do # rubocop:disable RSpec/RepeatedExampleGroupBody
         # TODO: issue-644: multi-AGW: add unit tests for multi-AGWs
         it 'should create a network interface without error'
 

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
@@ -451,6 +451,7 @@ describe Bosh::AzureCloud::AzureClient do
         end
       end
 
+      # NOTE: issue-644: unit tests for single-AGW, single-pool
       context 'with application gateway' do
         let(:nic_params) do
           {
@@ -537,6 +538,36 @@ describe Bosh::AzureCloud::AzureClient do
           expect do
             azure_client.create_network_interface(resource_group, nic_params)
           end.not_to raise_error
+        end
+
+        context 'with multiple backend pools' do
+          # TODO: issue-644: multi-BEPool-AGW: add unit tests for multi-pool AGWs
+          it 'should create a network interface without error'
+
+          context 'when backend_pool_name is specified' do
+            # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
+            it 'should use the specified backend_pool'
+          end
+
+          context 'when an invalid backend_pool_name is specified' do
+            # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
+            it 'should raise an error'
+          end
+        end
+      end
+
+      context 'with multiple application gateways' do
+        # TODO: issue-644: multi-AGW: add unit tests for multi-AGWs
+        it 'should create a network interface without error'
+
+        context 'with multiple backend pools' do
+          # TODO: issue-644: multi-BEPool-AGW: add unit tests for multi-pool AGWs
+          it 'should create a network interface without error'
+
+          context 'when backend_pool_name is specified' do
+            # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
+            it 'should use the specified backend_pool'
+          end
         end
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
@@ -429,10 +429,6 @@ describe Bosh::AzureCloud::AzureClient do
                   # which would remove all but the `vm_props`-configured pool from the list.
                   load_balancers: [{
                     backend_address_pools: [
-                      # {
-                      #   name: 'fake-lb-pool-name',
-                      #   id: 'fake-lb-pool-id'
-                      # },
                       {
                         name: 'fake-lb-pool2-name',
                         id: 'fake-lb-pool2-id'
@@ -455,11 +451,6 @@ describe Bosh::AzureCloud::AzureClient do
               end
             end
           end
-
-          # NOTE: This should never happen, since an error would be raised earlier (preventing `azure_client.create_network_interface` from being called)
-          # context 'when an invalid backend_pool_name is specified' do
-          #   it 'should never happen'
-          # end
         end
 
         context 'with multiple load balancers' do
@@ -600,10 +591,6 @@ describe Bosh::AzureCloud::AzureClient do
                   load_balancers: [
                     {
                       backend_address_pools: [
-                        # {
-                        #   name: 'fake-lb-pool-name',
-                        #   id: 'fake-lb-pool-id'
-                        # },
                         {
                           name: 'fake-lb-pool2-name',
                           id: 'fake-lb-pool2-id'
@@ -617,10 +604,6 @@ describe Bosh::AzureCloud::AzureClient do
                     },
                     {
                       backend_address_pools: [
-                        # {
-                        #   name: 'fake-lb2-pool-1-name',
-                        #   id: 'fake-lb2-pool-1-id'
-                        # },
                         {
                           name: 'fake-lb2-pool-2-name',
                           id: 'fake-lb2-pool-2-id'
@@ -886,10 +869,6 @@ describe Bosh::AzureCloud::AzureClient do
                   application_gateways: [
                     {
                       backend_address_pools: [
-                        # {
-                        #   name: 'fake-agw-pool-name',
-                        #   id: 'fake-agw-pool-id'
-                        # },
                         {
                           name: 'fake-agw-pool2-name',
                           id: 'fake-agw-pool2-id'
@@ -907,11 +886,6 @@ describe Bosh::AzureCloud::AzureClient do
               end
             end
           end
-
-          # NOTE: This should never happen, since an error would be raised earlier (preventing `azure_client.create_network_interface` from being called)
-          # context 'when an invalid backend_pool_name is specified' do
-          #   it 'should never happen'
-          # end
         end
 
         context 'with multiple application gateways' do
@@ -1033,10 +1007,6 @@ describe Bosh::AzureCloud::AzureClient do
                   application_gateways: [
                     {
                       backend_address_pools: [
-                        # {
-                        #   name: 'fake-agw-pool-name',
-                        #   id: 'fake-agw-pool-id'
-                        # },
                         {
                           name: 'fake-agw-pool2-name',
                           id: 'fake-agw-pool2-id'
@@ -1045,10 +1015,6 @@ describe Bosh::AzureCloud::AzureClient do
                     },
                     {
                       backend_address_pools: [
-                        # {
-                        #   name: 'fake-agw2-pool-1-name',
-                        #   id: 'fake-agw2-pool-1-id'
-                        # },
                         {
                           name: 'fake-agw2-pool-2-name',
                           id: 'fake-agw2-pool-2-id'

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
@@ -56,7 +56,7 @@ describe Bosh::AzureCloud::AzureClient do
             network_security_group: { id: nsg_id },
             application_security_groups: [],
             load_balancers: nil,
-            application_gateway: nil
+            application_gateways: nil
           }
         end
         let(:request_body) do
@@ -131,7 +131,7 @@ describe Bosh::AzureCloud::AzureClient do
             network_security_group: { id: nsg_id },
             application_security_groups: [],
             load_balancers: nil,
-            application_gateway: nil
+            application_gateways: nil
           }
         end
         let(:request_body) do
@@ -209,7 +209,7 @@ describe Bosh::AzureCloud::AzureClient do
             network_security_group: nil,
             application_security_groups: [],
             load_balancers: nil,
-            application_gateway: nil
+            application_gateways: nil
           }
         end
         let(:request_body) do
@@ -296,7 +296,7 @@ describe Bosh::AzureCloud::AzureClient do
                 }
               ]
             }],
-            application_gateway: nil
+            application_gateways: nil
           }
         end
 
@@ -381,7 +381,7 @@ describe Bosh::AzureCloud::AzureClient do
             network_security_group: { id: nsg_id },
             application_security_groups: [{ id: 'fake-asg-id-1' }, { id: 'fake-asg-id-2' }],
             load_balancers: nil,
-            application_gateway: nil
+            application_gateways: nil
           }
         end
         let(:request_body) do
@@ -467,13 +467,13 @@ describe Bosh::AzureCloud::AzureClient do
             network_security_group: { id: nsg_id },
             application_security_groups: [],
             load_balancers: nil,
-            application_gateway: {
+            application_gateways: [{
               backend_address_pools: [
                 {
                   id: 'fake-id-2'
                 }
               ]
-            }
+            }]
           }
         end
         let(:request_body) do

--- a/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
@@ -183,7 +183,12 @@ describe Bosh::AzureCloud::AzureClient do
       'properties' => {
         'provisioningState' => 'fake-state',
         'backendAddressPools' => [{
-          'id' => 'fake-id'
+          'name' => 'fake-name',
+          'id' => 'fake-id',
+          'properties' => {
+            'provisioningState' => 'fake-state',
+            'backendIPConfigurations' => []
+          }
         }]
       }
     }.to_json
@@ -196,7 +201,10 @@ describe Bosh::AzureCloud::AzureClient do
       tags: 'fake-tags',
       backend_address_pools: [
         {
-          id: 'fake-id'
+          name: 'fake-name',
+          id: 'fake-id',
+          provisioning_state: 'fake-state',
+          backend_ip_configurations: []
         }
       ]
     }

--- a/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
@@ -655,24 +655,44 @@ describe Bosh::AzureCloud::AzureClient do
           headers: {}
         )
         expect(
-          azure_client.get_application_gateway_by_name(application_gateway_name)
+          azure_client.get_application_gateway_by_name(nil, application_gateway_name)
         ).to be_nil
       end
 
-      it 'should return the resource if response body is not null' do
-        stub_request(:get, application_gateway_uri).to_return(
-          status: 200,
-          body: application_gateway_response_body,
-          headers: {}
-        )
-        stub_request(:get, public_ip_uri).to_return(
-          status: 200,
-          body: public_ip_response_body.to_json,
-          headers: {}
-        )
-        expect(
-          azure_client.get_application_gateway_by_name(application_gateway_name)
-        ).to eq(fake_application_gateway)
+      context 'when resource_group_name is not specified' do
+        it 'should return the resource if response body is not null' do
+          stub_request(:get, application_gateway_uri).to_return(
+            status: 200,
+            body: application_gateway_response_body,
+            headers: {}
+          )
+          stub_request(:get, public_ip_uri).to_return(
+            status: 200,
+            body: public_ip_response_body.to_json,
+            headers: {}
+          )
+          expect(
+            azure_client.get_application_gateway_by_name(nil, application_gateway_name)
+          ).to eq(fake_application_gateway)
+        end
+      end
+
+      context 'when resource_group_name is specified' do
+        it 'should return the resource if response body is not null' do
+          stub_request(:get, application_gateway_uri).to_return(
+            status: 200,
+            body: application_gateway_response_body,
+            headers: {}
+          )
+          stub_request(:get, public_ip_uri).to_return(
+            status: 200,
+            body: public_ip_response_body.to_json,
+            headers: {}
+          )
+          expect(
+            azure_client.get_application_gateway_by_name(default_resource_group_name, application_gateway_name)
+          ).to eq(fake_application_gateway)
+        end
       end
     end
   end
@@ -880,7 +900,7 @@ describe Bosh::AzureCloud::AzureClient do
             ip_configuration_id: 'fake-id',
             private_ip: '10.0.0.100',
             private_ip_allocation_method: 'Dynamic',
-            application_gateway: fake_application_gateway
+            application_gateways: [fake_application_gateway]
           }
         end
         it 'should return the network interface with load balancer' do

--- a/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
@@ -816,7 +816,7 @@ describe Bosh::AzureCloud::AzureClient do
             ip_configuration_id: 'fake-id',
             private_ip: '10.0.0.100',
             private_ip_allocation_method: 'Dynamic',
-            load_balancer: fake_load_balancer
+            load_balancers: [fake_load_balancer]
           }
         end
         it 'should return the network interface with load balancer' do

--- a/src/bosh_azure_cpi/spec/unit/azure_client/list_network_interfaces_by_keyword_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/list_network_interfaces_by_keyword_spec.rb
@@ -167,7 +167,7 @@ describe Bosh::AzureCloud::AzureClient do
           private_ip_allocation_method: 'f0',
           network_security_group: { id: 'i' },
           public_ip: { id: 'j' },
-          load_balancer: { id: 'k' },
+          load_balancers: [{ id: 'k' }],
           application_gateway: { id: 'l' },
           application_security_groups: [{ id: 'asg-id-1' }]
         }

--- a/src/bosh_azure_cpi/spec/unit/azure_client/list_network_interfaces_by_keyword_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/list_network_interfaces_by_keyword_spec.rb
@@ -168,7 +168,7 @@ describe Bosh::AzureCloud::AzureClient do
           network_security_group: { id: 'i' },
           public_ip: { id: 'j' },
           load_balancers: [{ id: 'k' }],
-          application_gateway: { id: 'l' },
+          application_gateways: [{ id: 'l' }],
           application_security_groups: [{ id: 'asg-id-1' }]
         }
       end

--- a/src/bosh_azure_cpi/spec/unit/models/application_gateway_config_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/models/application_gateway_config_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Bosh::AzureCloud::ApplicationGatewayConfig do
+  describe '#to_s' do
+    context 'when called' do
+      let(:name) { 'fake_name' }
+      let(:resource_group_name) { 'fake_rg' }
+      let(:lb_string) { "name: #{name}, resource_group_name: #{resource_group_name}" }
+      let(:application_gateway_config) { Bosh::AzureCloud::ApplicationGatewayConfig.new(resource_group_name, name) }
+
+      it 'should return the correct string' do
+        expect(application_gateway_config.to_s).to eq(lb_string)
+      end
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/models/application_gateway_config_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/models/application_gateway_config_spec.rb
@@ -7,11 +7,12 @@ describe Bosh::AzureCloud::ApplicationGatewayConfig do
     context 'when called' do
       let(:name) { 'fake_name' }
       let(:resource_group_name) { 'fake_rg' }
-      let(:lb_string) { "name: #{name}, resource_group_name: #{resource_group_name}" }
-      let(:application_gateway_config) { Bosh::AzureCloud::ApplicationGatewayConfig.new(resource_group_name, name) }
+      let(:backend_pool_name) { 'fake_pool' }
+      let(:expected_string) { "name: #{name}, resource_group_name: #{resource_group_name}, backend_pool_name: #{backend_pool_name}" }
+      let(:application_gateway_config) { Bosh::AzureCloud::ApplicationGatewayConfig.new(resource_group_name, name, backend_pool_name) }
 
       it 'should return the correct string' do
-        expect(application_gateway_config.to_s).to eq(lb_string)
+        expect(application_gateway_config.to_s).to eq(expected_string)
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/models/load_balancer_config_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/models/load_balancer_config_spec.rb
@@ -7,11 +7,12 @@ describe Bosh::AzureCloud::LoadBalancerConfig do
     context 'when called' do
       let(:name) { 'fake_name' }
       let(:resource_group_name) { 'fake_rg' }
-      let(:lb_string) { "name: #{name}, resource_group_name: #{resource_group_name}" }
-      let(:load_balancer_config) { Bosh::AzureCloud::LoadBalancerConfig.new(resource_group_name, name) }
+      let(:backend_pool_name) { 'fake_pool' }
+      let(:expected_string) { "name: #{name}, resource_group_name: #{resource_group_name}, backend_pool_name: #{backend_pool_name}" }
+      let(:load_balancer_config) { Bosh::AzureCloud::LoadBalancerConfig.new(resource_group_name, name, backend_pool_name) }
 
       it 'should return the correct string' do
-        expect(load_balancer_config.to_s).to eq(lb_string)
+        expect(load_balancer_config.to_s).to eq(expected_string)
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/models/vm_cloud_props_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/models/vm_cloud_props_spec.rb
@@ -228,7 +228,6 @@ describe Bosh::AzureCloud::VMCloudProps do
               'fake_lb1_name', # String
               {
                 'name' => 'fake_lb2_name'
-                # 'resource_group_name' => resource_group_name
               }, # Hash without resource_group_name
               'fake_lb3_name,fake_lb4_name', # delimited String
               {
@@ -368,7 +367,6 @@ describe Bosh::AzureCloud::VMCloudProps do
               'fake_agw1_name', # String
               {
                 'name' => 'fake_agw2_name'
-                # 'resource_group_name' => resource_group_name
               }, # Hash without resource_group_name
               'fake_agw3_name,fake_agw4_name', # delimited String
               {

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/application_security_group_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/application_security_group_spec.rb
@@ -597,7 +597,7 @@ describe Bosh::AzureCloud::VMManager do
                                                 public_ip: dynamic_public_ip,
                                                 subnet: subnet,
                                                 tags: tags,
-                                                load_balancer: [ load_balancer ],
+                                                load_balancers: [ load_balancer ],
                                                 application_gateway: application_gateway
                                               )).once
 
@@ -625,7 +625,7 @@ describe Bosh::AzureCloud::VMManager do
                                                 public_ip: dynamic_public_ip,
                                                 subnet: subnet,
                                                 tags: tags,
-                                                load_balancer: [ load_balancer ],
+                                                load_balancers: [ load_balancer ],
                                                 application_gateway: application_gateway
                                               ))
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/application_security_group_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/application_security_group_spec.rb
@@ -598,7 +598,7 @@ describe Bosh::AzureCloud::VMManager do
                                                 subnet: subnet,
                                                 tags: tags,
                                                 load_balancers: [ load_balancer ],
-                                                application_gateway: application_gateway
+                                                application_gateways: [application_gateway]
                                               )).once
 
             _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
@@ -626,7 +626,7 @@ describe Bosh::AzureCloud::VMManager do
                                                 subnet: subnet,
                                                 tags: tags,
                                                 load_balancers: [ load_balancer ],
-                                                application_gateway: application_gateway
+                                                application_gateways: [application_gateway]
                                               ))
 
             _, vm_params = vm_manager.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
@@ -58,6 +58,7 @@ describe Bosh::AzureCloud::VMManager do
               .and_return(name: storage_account_name)
           end
 
+          # TODO: issue-644: multi-BEPool-AGW: use this spec as a template for the pending specs below
           it 'creates a public IP and assigns it to the primary NIC' do
             expect(azure_client).to receive(:create_public_ip)
               .with(MOCK_RESOURCE_GROUP_NAME, public_ip_params)
@@ -73,6 +74,33 @@ describe Bosh::AzureCloud::VMManager do
 
             _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
             expect(vm_params[:name]).to eq(vm_name)
+          end
+
+          context 'with single application_gateway' do
+            context 'when application_gateway has multiple backend pools' do
+              # TODO: issue-644: multi-BEPool-AGW: add unit tests for multi-pool AGWs
+              it 'adds the public IP to the default pool'
+
+              context 'when backend_pool_name is specified' do
+                # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
+                it 'adds the public IP to the specified pool'
+              end
+
+              context 'when an invalid backend_pool_name is specified' do
+                # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
+                it 'should raise an error'
+              end
+            end
+          end
+
+          context 'with multiple application_gateways' do
+            # TODO: issue-644: multi-AGW: add unit tests for multi-AGWs
+            it 'adds the public IP to each application_gateway'
+
+            context 'when backend_pool_name is specified' do
+              # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
+              it 'adds the public IP to the specified pool of each application_gateway'
+            end
           end
         end
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
@@ -76,6 +76,33 @@ describe Bosh::AzureCloud::VMManager do
             expect(vm_params[:name]).to eq(vm_name)
           end
 
+          context 'with single load_balancer' do
+            context 'when load_balancer has multiple backend pools' do
+              # TODO: issue-644: multi-BEPool-LB: add unit tests for multi-pool LBs
+              it 'adds the public IP to the default pool'
+
+              context 'when backend_pool_name is specified' do
+                # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
+                it 'adds the public IP to the specified pool'
+              end
+
+              context 'when an invalid backend_pool_name is specified' do
+                # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
+                it 'should raise an error'
+              end
+            end
+          end
+
+          context 'with multiple load_balancers' do
+            # TODO: issue-644: multi-LB: add unit tests for multi-LBs
+            it 'adds the public IP to each load_balancer'
+
+            context 'when backend_pool_name is specified' do
+              # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
+              it 'adds the public IP to the specified pool of each load_balancer'
+            end
+          end
+
           context 'with single application_gateway' do
             context 'when application_gateway has multiple backend pools' do
               # TODO: issue-644: multi-BEPool-AGW: add unit tests for multi-pool AGWs

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
@@ -67,7 +67,7 @@ describe Bosh::AzureCloud::VMManager do
                                                 public_ip: dynamic_public_ip,
                                                 subnet: subnet,
                                                 tags: tags,
-                                                load_balancer: [ load_balancer ],
+                                                load_balancers: [ load_balancer ],
                                                 application_gateway: application_gateway
                                               )).once
 
@@ -95,7 +95,7 @@ describe Bosh::AzureCloud::VMManager do
                                                 public_ip: dynamic_public_ip,
                                                 subnet: subnet,
                                                 tags: tags,
-                                                load_balancer: [ load_balancer ],
+                                                load_balancers: [ load_balancer ],
                                                 application_gateway: application_gateway
                                               ))
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
@@ -58,75 +58,486 @@ describe Bosh::AzureCloud::VMManager do
               .and_return(name: storage_account_name)
           end
 
-          # TODO: issue-644: multi-BEPool-AGW: use this spec as a template for the pending specs below
-          it 'creates a public IP and assigns it to the primary NIC' do
-            expect(azure_client).to receive(:create_public_ip)
-              .with(MOCK_RESOURCE_GROUP_NAME, public_ip_params)
-            expect(azure_client).to receive(:create_network_interface)
-              .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
-                                                name: "#{vm_name}-0",
-                                                public_ip: dynamic_public_ip,
-                                                subnet: subnet,
-                                                tags: tags,
-                                                load_balancers: [ load_balancer ],
-                                                application_gateways: [application_gateway]
-                                              )).once
+          context 'with valid load_balancer config' do
+            context 'with single load_balancer' do
+              before do
+                expect(azure_client).to receive(:create_public_ip)
+                  .with(MOCK_RESOURCE_GROUP_NAME, public_ip_params)
+                expect(azure_client).to receive(:create_network_interface)
+                  .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
+                                                    name: "#{vm_name}-0",
+                                                    public_ip: dynamic_public_ip,
+                                                    subnet: subnet,
+                                                    tags: tags,
+                                                    load_balancers: [ load_balancer ],
+                                                    application_gateways: [application_gateway]
+                                                  )).once
+              end
 
-            _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
-            expect(vm_params[:name]).to eq(vm_name)
-          end
+              it 'creates a public IP and assigns it to the primary NIC' do
+                _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                expect(vm_params[:name]).to eq(vm_name)
+                # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the NIC correctly.
+              end
 
-          context 'with single load_balancer' do
-            context 'when load_balancer has multiple backend pools' do
-              # TODO: issue-644: multi-BEPool-LB: add unit tests for multi-pool LBs
-              it 'adds the public IP to the default pool'
+              context 'when load_balancer has multiple backend pools' do
+                let(:load_balancer) do
+                  {
+                    name: 'fake-lb-name',
+                    backend_address_pools: [
+                      {
+                        name: 'fake-pool-name',
+                        id: 'fake-pool-id',
+                        provisioning_state: 'fake-pool-state',
+                        backend_ip_configurations: []
+                      },
+                      {
+                        name: 'fake-pool2-name',
+                        id: 'fake-pool2-id',
+                        provisioning_state: 'fake-pool2-state',
+                        backend_ip_configurations: []
+                      }
+                    ]
+                  }
+                end
+
+                context 'when backend_pool_name is not specified' do
+                  let(:vm_properties) do
+                    {
+                      'instance_type' => 'Standard_D1',
+                      'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                      'caching' => 'ReadWrite',
+                      'load_balancer' => {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-lb-name'
+                        # 'backend_pool_name' => 'fake-pool2-name'
+                      },
+                      'application_gateway' => 'fake-ag-name'
+                    }
+                  end
+
+                  it 'adds the public IP to the default pool' do
+                    _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                    expect(vm_params[:name]).to eq(vm_name)
+                    # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the correct pool(s).
+                  end
+                end
+
+                context 'when backend_pool_name is specified' do
+                  let(:vm_properties) do
+                    {
+                      'instance_type' => 'Standard_D1',
+                      'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                      'caching' => 'ReadWrite',
+                      'load_balancer' => {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-lb-name',
+                        'backend_pool_name' => 'fake-pool2-name'
+                      },
+                      'application_gateway' => 'fake-ag-name'
+                    }
+                  end
+
+                  it 'adds the public IP to the specified pool' do
+                    _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                    expect(vm_params[:name]).to eq(vm_name)
+                    # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the correct pool(s).
+                  end
+                end
+              end
+            end
+
+            context 'with multiple load_balancers' do
+              let(:load_balancer) do
+                [
+                  {
+                    name: 'fake-lb-name',
+                    backend_address_pools: [
+                      {
+                        name: 'fake-pool-name',
+                        id: 'fake-pool-id',
+                        provisioning_state: 'fake-pool-state',
+                        backend_ip_configurations: []
+                      },
+                      {
+                        name: 'fake-pool2-name',
+                        id: 'fake-pool2-id',
+                        provisioning_state: 'fake-pool2-state',
+                        backend_ip_configurations: []
+                      }
+                    ]
+                  },
+                  {
+                    name: 'fake-lb2-name',
+                    backend_address_pools: [
+                      {
+                        name: 'fake-lb2-pool-1-name',
+                        id: 'fake-lb2-pool-1-id',
+                        provisioning_state: 'fake-lb2-pool-1-state',
+                        backend_ip_configurations: []
+                      },
+                      {
+                        name: 'fake-lb2-pool-2-name',
+                        id: 'fake-lb2-pool-2-id',
+                        provisioning_state: 'fake-lb2-pool-2-state',
+                        backend_ip_configurations: []
+                      }
+                    ]
+                  }
+                ]
+              end
+
+              before do
+                expect(azure_client).to receive(:create_public_ip)
+                  .with(MOCK_RESOURCE_GROUP_NAME, public_ip_params)
+                expect(azure_client).to receive(:create_network_interface)
+                  .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
+                                                    name: "#{vm_name}-0",
+                                                    public_ip: dynamic_public_ip,
+                                                    subnet: subnet,
+                                                    tags: tags,
+                                                    load_balancers: load_balancer,
+                                                    application_gateways: [application_gateway]
+                                                  )).once
+                allow(azure_client).to receive(:get_load_balancer_by_name)
+                  .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
+                  .and_return(load_balancer.first)
+                allow(azure_client).to receive(:get_load_balancer_by_name)
+                  .with(vm_props.load_balancers[1].resource_group_name, vm_props.load_balancers[1].name)
+                  .and_return(load_balancer[1])
+              end
+
+              context 'when backend_pool_name is not specified' do
+                let(:vm_properties) do
+                  {
+                    'instance_type' => 'Standard_D1',
+                    'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                    'caching' => 'ReadWrite',
+                    'load_balancer' => [
+                      {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-lb-name'
+                        # 'backend_pool_name' => 'fake-pool2-name'
+                      },
+                      {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-lb2-name'
+                        # 'backend_pool_name' => 'fake-lb2-pool-2-name'
+                      }
+                    ],
+                    'application_gateway' => 'fake-ag-name'
+                  }
+                end
+
+                it 'adds the public IP to the default pool of each load_balancer' do
+                  _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                  expect(vm_params[:name]).to eq(vm_name)
+                  # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IPs was assigned to the correct pool(s).
+                end
+              end
 
               context 'when backend_pool_name is specified' do
-                # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
-                it 'adds the public IP to the specified pool'
-              end
+                let(:vm_properties) do
+                  {
+                    'instance_type' => 'Standard_D1',
+                    'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                    'caching' => 'ReadWrite',
+                    'load_balancer' => [
+                      {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-lb-name',
+                        'backend_pool_name' => 'fake-pool2-name'
+                      },
+                      {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-lb2-name',
+                        'backend_pool_name' => 'fake-lb2-pool-2-name'
+                      }
+                    ],
+                    'application_gateway' => 'fake-ag-name'
+                  }
+                end
 
-              context 'when an invalid backend_pool_name is specified' do
-                # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
-                it 'should raise an error'
+                it 'adds the public IP to the specified pool of each load_balancer' do
+                  _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                  expect(vm_params[:name]).to eq(vm_name)
+                  # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the correct pool(s).
+                end
               end
             end
           end
 
-          context 'with multiple load_balancers' do
-            # TODO: issue-644: multi-LB: add unit tests for multi-LBs
-            it 'adds the public IP to each load_balancer'
+          context 'with invalid load_balancer config' do
+            context 'when an invalid backend_pool_name is specified' do
+              let(:vm_properties) do
+                {
+                  'instance_type' => 'Standard_D1',
+                  'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                  'caching' => 'ReadWrite',
+                  'load_balancer' => {
+                    # 'resource_group_name' => 'fake-rg-name',
+                    'name' => 'fake-lb-name',
+                    'backend_pool_name' => 'invalid-pool-name'
+                  },
+                  'application_gateway' => 'fake-ag-name'
+                }
+              end
 
-            context 'when backend_pool_name is specified' do
-              # TODO: issue-644: multi-BEPool-LB: add unit tests for named-pool LBs
-              it 'adds the public IP to the specified pool of each load_balancer'
+              it 'should raise an error' do
+                expect(azure_client).to receive(:create_public_ip)
+                  .with(MOCK_RESOURCE_GROUP_NAME, public_ip_params)
+                expect(azure_client).to receive(:delete_public_ip).with(MOCK_RESOURCE_GROUP_NAME, vm_name)
+                # NOTE: For some reason, the following mock is needed when a `cloud_error` is raised
+                allow(azure_client).to receive(:list_network_interfaces_by_keyword)
+                  .with(MOCK_RESOURCE_GROUP_NAME, vm_name)
+                  .and_return([]).once
+
+                expect do
+                  vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                end.to raise_error(/('fake-lb-name' does not have a backend_pool named 'invalid-pool-name': \{:name=>"fake-lb-name", :backend_address_pools=>\[\{:name=>"fake-pool-name", :id=>"fake-pool-id", ).*/)
+              end
             end
           end
 
-          context 'with single application_gateway' do
-            context 'when application_gateway has multiple backend pools' do
-              # TODO: issue-644: multi-BEPool-AGW: add unit tests for multi-pool AGWs
-              it 'adds the public IP to the default pool'
+          context 'with valid application_gateway config' do
+            context 'with single application_gateway' do
+              before do
+                expect(azure_client).to receive(:create_public_ip)
+                  .with(MOCK_RESOURCE_GROUP_NAME, public_ip_params)
+                expect(azure_client).to receive(:create_network_interface)
+                  .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
+                                                    name: "#{vm_name}-0",
+                                                    public_ip: dynamic_public_ip,
+                                                    subnet: subnet,
+                                                    tags: tags,
+                                                    load_balancers: [ load_balancer ],
+                                                    application_gateways: [application_gateway]
+                                                  )).once
+              end
+
+              # NOTE: The following spec is currently identical/redundant to the '.../with single load_balancer/creates a public IP and assigns it to the primary NIC' spec above. Ideally, each of them SHOULD have distinct expectations, but currently they don't.
+              it 'creates a public IP and assigns it to the primary NIC' do
+                _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                expect(vm_params[:name]).to eq(vm_name)
+                # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the NIC correctly.
+              end
+
+              context 'when application_gateway has multiple backend pools' do
+                let(:application_gateway) do
+                  {
+                    name: 'fake-ag-name',
+                    backend_address_pools: [
+                      {
+                        name: 'fake-pool-name',
+                        id: 'fake-pool-id',
+                        provisioning_state: 'fake-pool-state',
+                        backend_ip_configurations: []
+                      },
+                      {
+                        name: 'fake-pool2-name',
+                        id: 'fake-pool2-id',
+                        provisioning_state: 'fake-pool2-state',
+                        backend_ip_configurations: []
+                      }
+                    ]
+                  }
+                end
+
+                context 'when backend_pool_name is not specified' do
+                  let(:vm_properties) do
+                    {
+                      'instance_type' => 'Standard_D1',
+                      'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                      'caching' => 'ReadWrite',
+                      'load_balancer' => 'fake-lb-name',
+                      'application_gateway' => {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-ag-name'
+                        # 'backend_pool_name' => 'fake-pool2-name'
+                      }
+                    }
+                  end
+
+                  it 'adds the public IP to the default pool' do
+                    _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                    expect(vm_params[:name]).to eq(vm_name)
+                    # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the correct pool(s).
+                  end
+                end
+
+                context 'when backend_pool_name is specified' do
+                  let(:vm_properties) do
+                    {
+                      'instance_type' => 'Standard_D1',
+                      'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                      'caching' => 'ReadWrite',
+                      'load_balancer' => 'fake-lb-name',
+                      'application_gateway' => {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-ag-name',
+                        'backend_pool_name' => 'fake-pool2-name'
+                      }
+                    }
+                  end
+
+                  it 'adds the public IP to the specified pool' do
+                    _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                    expect(vm_params[:name]).to eq(vm_name)
+                    # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the correct pool(s).
+                  end
+                end
+              end
+            end
+
+            context 'with multiple application_gateways' do
+              let(:application_gateway) do
+                [
+                  {
+                    name: 'fake-ag-name',
+                    backend_address_pools: [
+                      {
+                        name: 'fake-pool-name',
+                        id: 'fake-pool-id',
+                        provisioning_state: 'fake-pool-state',
+                        backend_ip_configurations: []
+                      },
+                      {
+                        name: 'fake-pool2-name',
+                        id: 'fake-pool2-id',
+                        provisioning_state: 'fake-pool2-state',
+                        backend_ip_configurations: []
+                      }
+                    ]
+                  },
+                  {
+                    name: 'fake-ag2-name',
+                    backend_address_pools: [
+                      {
+                        name: 'fake-ag2-pool-1-name',
+                        id: 'fake-ag2-pool-1-id',
+                        provisioning_state: 'fake-ag2-pool-1-state',
+                        backend_ip_configurations: []
+                      },
+                      {
+                        name: 'fake-ag2-pool-2-name',
+                        id: 'fake-ag2-pool-2-id',
+                        provisioning_state: 'fake-ag2-pool-2-state',
+                        backend_ip_configurations: []
+                      }
+                    ]
+                  }
+                ]
+              end
+
+              before do
+                expect(azure_client).to receive(:create_public_ip)
+                  .with(MOCK_RESOURCE_GROUP_NAME, public_ip_params)
+                expect(azure_client).to receive(:create_network_interface)
+                  .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
+                                                    name: "#{vm_name}-0",
+                                                    public_ip: dynamic_public_ip,
+                                                    subnet: subnet,
+                                                    tags: tags,
+                                                    load_balancers: [ load_balancer ],
+                                                    application_gateways: application_gateway
+                                                  )).once
+                allow(azure_client).to receive(:get_application_gateway_by_name)
+                  .with(vm_props.application_gateways.first.resource_group_name, vm_props.application_gateways.first.name)
+                  .and_return(application_gateway.first)
+                allow(azure_client).to receive(:get_application_gateway_by_name)
+                  .with(vm_props.application_gateways[1].resource_group_name, vm_props.application_gateways[1].name)
+                  .and_return(application_gateway[1])
+              end
+
+              context 'when backend_pool_name is not specified' do
+                let(:vm_properties) do
+                  {
+                    'instance_type' => 'Standard_D1',
+                    'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                    'caching' => 'ReadWrite',
+                    'load_balancer' => 'fake-lb-name',
+                    'application_gateway' => [
+                      {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-ag-name'
+                        # 'backend_pool_name' => 'fake-pool2-name'
+                      },
+                      {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-ag2-name'
+                        # 'backend_pool_name' => 'fake-ag2-pool-2-name'
+                      }
+                    ]
+                  }
+                end
+
+                it 'adds the public IP to the default pool of each application_gateway' do
+                  _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                  expect(vm_params[:name]).to eq(vm_name)
+                  # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the correct pool(s).
+                end
+              end
 
               context 'when backend_pool_name is specified' do
-                # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
-                it 'adds the public IP to the specified pool'
-              end
+                let(:vm_properties) do
+                  {
+                    'instance_type' => 'Standard_D1',
+                    'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                    'caching' => 'ReadWrite',
+                    'load_balancer' => 'fake-lb-name',
+                    'application_gateway' => [
+                      {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-ag-name',
+                        'backend_pool_name' => 'fake-pool2-name'
+                      },
+                      {
+                        # 'resource_group_name' => 'fake-rg-name',
+                        'name' => 'fake-ag2-name',
+                        'backend_pool_name' => 'fake-ag2-pool-2-name'
+                      }
+                    ]
+                  }
+                end
 
-              context 'when an invalid backend_pool_name is specified' do
-                # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
-                it 'should raise an error'
+                it 'adds the public IP to the specified pool of each application_gateway' do
+                  _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                  expect(vm_params[:name]).to eq(vm_name)
+                  # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the correct pool(s).
+                end
               end
             end
           end
 
-          context 'with multiple application_gateways' do
-            # TODO: issue-644: multi-AGW: add unit tests for multi-AGWs
-            it 'adds the public IP to each application_gateway'
+          context 'with invalid application_gateway config' do
+            context 'when an invalid backend_pool_name is specified' do
+              let(:vm_properties) do
+                {
+                  'instance_type' => 'Standard_D1',
+                  'storage_account_name' => 'dfe03ad623f34d42999e93ca',
+                  'caching' => 'ReadWrite',
+                  'load_balancer' => 'fake-lb-name',
+                  'application_gateway' => {
+                    # 'resource_group_name' => 'fake-rg-name',
+                    'name' => 'fake-ag-name',
+                    'backend_pool_name' => 'invalid-pool-name'
+                  }
+                }
+              end
 
-            context 'when backend_pool_name is specified' do
-              # TODO: issue-644: multi-BEPool-AGW: add unit tests for named-pool AGWs
-              it 'adds the public IP to the specified pool of each application_gateway'
+              it 'should raise an error' do
+                expect(azure_client).to receive(:create_public_ip)
+                  .with(MOCK_RESOURCE_GROUP_NAME, public_ip_params)
+                expect(azure_client).to receive(:delete_public_ip).with(MOCK_RESOURCE_GROUP_NAME, vm_name)
+                # NOTE: For some reason, the following mock is needed when a `cloud_error` is raised
+                allow(azure_client).to receive(:list_network_interfaces_by_keyword)
+                  .with(MOCK_RESOURCE_GROUP_NAME, vm_name)
+                  .and_return([]).once
+
+                expect do
+                  vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+                end.to raise_error(/('fake-ag-name' does not have a backend_pool named 'invalid-pool-name': \{:name=>"fake-ag-name", :backend_address_pools=>\[\{:name=>"fake-pool-name", :id=>"fake-pool-id", ).*/)
+              end
             end
           end
         end
@@ -156,6 +567,7 @@ describe Bosh::AzureCloud::VMManager do
 
             _, vm_params = vm_manager.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
             expect(vm_params[:name]).to eq(vm_name)
+            # TODO: Add more expectations here? The expects above only verify that the VM was created, but not that the IP was assigned to the NIC correctly.
           end
         end
       end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
@@ -108,9 +108,7 @@ describe Bosh::AzureCloud::VMManager do
                       'storage_account_name' => 'dfe03ad623f34d42999e93ca',
                       'caching' => 'ReadWrite',
                       'load_balancer' => {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-lb-name'
-                        # 'backend_pool_name' => 'fake-pool2-name'
                       },
                       'application_gateway' => 'fake-ag-name'
                     }
@@ -130,7 +128,6 @@ describe Bosh::AzureCloud::VMManager do
                       'storage_account_name' => 'dfe03ad623f34d42999e93ca',
                       'caching' => 'ReadWrite',
                       'load_balancer' => {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-lb-name',
                         'backend_pool_name' => 'fake-pool2-name'
                       },
@@ -215,14 +212,10 @@ describe Bosh::AzureCloud::VMManager do
                     'caching' => 'ReadWrite',
                     'load_balancer' => [
                       {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-lb-name'
-                        # 'backend_pool_name' => 'fake-pool2-name'
                       },
                       {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-lb2-name'
-                        # 'backend_pool_name' => 'fake-lb2-pool-2-name'
                       }
                     ],
                     'application_gateway' => 'fake-ag-name'
@@ -244,12 +237,10 @@ describe Bosh::AzureCloud::VMManager do
                     'caching' => 'ReadWrite',
                     'load_balancer' => [
                       {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-lb-name',
                         'backend_pool_name' => 'fake-pool2-name'
                       },
                       {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-lb2-name',
                         'backend_pool_name' => 'fake-lb2-pool-2-name'
                       }
@@ -275,7 +266,6 @@ describe Bosh::AzureCloud::VMManager do
                   'storage_account_name' => 'dfe03ad623f34d42999e93ca',
                   'caching' => 'ReadWrite',
                   'load_balancer' => {
-                    # 'resource_group_name' => 'fake-rg-name',
                     'name' => 'fake-lb-name',
                     'backend_pool_name' => 'invalid-pool-name'
                   },
@@ -351,9 +341,7 @@ describe Bosh::AzureCloud::VMManager do
                       'caching' => 'ReadWrite',
                       'load_balancer' => 'fake-lb-name',
                       'application_gateway' => {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-ag-name'
-                        # 'backend_pool_name' => 'fake-pool2-name'
                       }
                     }
                   end
@@ -373,7 +361,6 @@ describe Bosh::AzureCloud::VMManager do
                       'caching' => 'ReadWrite',
                       'load_balancer' => 'fake-lb-name',
                       'application_gateway' => {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-ag-name',
                         'backend_pool_name' => 'fake-pool2-name'
                       }
@@ -458,14 +445,10 @@ describe Bosh::AzureCloud::VMManager do
                     'load_balancer' => 'fake-lb-name',
                     'application_gateway' => [
                       {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-ag-name'
-                        # 'backend_pool_name' => 'fake-pool2-name'
                       },
                       {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-ag2-name'
-                        # 'backend_pool_name' => 'fake-ag2-pool-2-name'
                       }
                     ]
                   }
@@ -487,12 +470,10 @@ describe Bosh::AzureCloud::VMManager do
                     'load_balancer' => 'fake-lb-name',
                     'application_gateway' => [
                       {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-ag-name',
                         'backend_pool_name' => 'fake-pool2-name'
                       },
                       {
-                        # 'resource_group_name' => 'fake-rg-name',
                         'name' => 'fake-ag2-name',
                         'backend_pool_name' => 'fake-ag2-pool-2-name'
                       }
@@ -518,7 +499,6 @@ describe Bosh::AzureCloud::VMManager do
                   'caching' => 'ReadWrite',
                   'load_balancer' => 'fake-lb-name',
                   'application_gateway' => {
-                    # 'resource_group_name' => 'fake-rg-name',
                     'name' => 'fake-ag-name',
                     'backend_pool_name' => 'invalid-pool-name'
                   }

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
@@ -68,7 +68,7 @@ describe Bosh::AzureCloud::VMManager do
                                                 subnet: subnet,
                                                 tags: tags,
                                                 load_balancers: [ load_balancer ],
-                                                application_gateway: application_gateway
+                                                application_gateways: [application_gateway]
                                               )).once
 
             _, vm_params = vm_manager_for_pip.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
@@ -96,7 +96,7 @@ describe Bosh::AzureCloud::VMManager do
                                                 subnet: subnet,
                                                 tags: tags,
                                                 load_balancers: [ load_balancer ],
-                                                application_gateway: application_gateway
+                                                application_gateways: [application_gateway]
                                               ))
 
             _, vm_params = vm_manager.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/invalid_option_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/invalid_option_spec.rb
@@ -25,7 +25,7 @@ describe Bosh::AzureCloud::VMManager do
             .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
             .and_return(load_balancer)
           allow(azure_client).to receive(:get_application_gateway_by_name)
-            .with(vm_props.application_gateway)
+            .with(vm_props.application_gateways.first.resource_group_name, vm_props.application_gateways.first.name)
             .and_return(application_gateway)
           allow(azure_client).to receive(:list_public_ips)
             .and_return([{
@@ -52,7 +52,7 @@ describe Bosh::AzureCloud::VMManager do
             .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
             .and_return(load_balancer)
           allow(azure_client).to receive(:get_application_gateway_by_name)
-            .with(vm_props.application_gateway)
+            .with(vm_props.application_gateways.first.resource_group_name, vm_props.application_gateways.first.name)
             .and_return(application_gateway)
           allow(azure_client).to receive(:list_public_ips)
             .and_return([{
@@ -82,7 +82,7 @@ describe Bosh::AzureCloud::VMManager do
           .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
           .and_return(load_balancer)
         allow(azure_client).to receive(:get_application_gateway_by_name)
-          .with(vm_props.application_gateway)
+          .with(vm_props.application_gateways.first.resource_group_name, vm_props.application_gateways.first.name)
           .and_return(application_gateway)
         allow(azure_client).to receive(:list_public_ips)
           .and_return([{
@@ -131,7 +131,7 @@ describe Bosh::AzureCloud::VMManager do
           .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
           .and_return(load_balancer)
         allow(azure_client).to receive(:get_application_gateway_by_name)
-          .with(vm_props.application_gateway)
+          .with(vm_props.application_gateways.first.resource_group_name, vm_props.application_gateways.first.name)
           .and_return(application_gateway)
       end
 
@@ -214,7 +214,7 @@ describe Bosh::AzureCloud::VMManager do
           .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
           .and_return(load_balancer)
         allow(azure_client).to receive(:get_application_gateway_by_name)
-          .with(vm_props.application_gateway)
+          .with(vm_props.application_gateways.first.resource_group_name, vm_props.application_gateways.first.name)
           .and_return(nil)
 
         expect(azure_client).not_to receive(:delete_virtual_machine)
@@ -234,7 +234,7 @@ describe Bosh::AzureCloud::VMManager do
           .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
           .and_return(load_balancer)
         allow(azure_client).to receive(:get_application_gateway_by_name)
-          .with(vm_props.application_gateway)
+          .with(vm_props.application_gateways.first.resource_group_name, vm_props.application_gateways.first.name)
           .and_return(application_gateway)
         allow(azure_client).to receive(:list_public_ips)
           .and_return([{
@@ -278,7 +278,7 @@ describe Bosh::AzureCloud::VMManager do
             .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
             .and_return(load_balancer)
           allow(azure_client).to receive(:get_application_gateway_by_name)
-            .with(vm_props.application_gateway)
+            .with(vm_props.application_gateways.first.resource_group_name, vm_props.application_gateways.first.name)
             .and_return(application_gateway)
           allow(azure_client).to receive(:list_public_ips)
             .and_return([{

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/invalid_option_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/invalid_option_spec.rb
@@ -22,7 +22,7 @@ describe Bosh::AzureCloud::VMManager do
             .with(MOCK_RESOURCE_GROUP_NAME, vm_name)
             .and_return([])
           allow(azure_client).to receive(:get_load_balancer_by_name)
-            .with(vm_props.load_balancer.resource_group_name, vm_props.load_balancer.name)
+            .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
             .and_return(load_balancer)
           allow(azure_client).to receive(:get_application_gateway_by_name)
             .with(vm_props.application_gateway)
@@ -49,7 +49,7 @@ describe Bosh::AzureCloud::VMManager do
             .with(MOCK_RESOURCE_GROUP_NAME, vm_name)
             .and_return([])
           allow(azure_client).to receive(:get_load_balancer_by_name)
-            .with(vm_props.load_balancer.resource_group_name, vm_props.load_balancer.name)
+            .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
             .and_return(load_balancer)
           allow(azure_client).to receive(:get_application_gateway_by_name)
             .with(vm_props.application_gateway)
@@ -79,7 +79,7 @@ describe Bosh::AzureCloud::VMManager do
         allow(manual_network).to receive(:resource_group_name)
           .and_return('fake-resource-group-name')
         allow(azure_client).to receive(:get_load_balancer_by_name)
-          .with(vm_props.load_balancer.resource_group_name, vm_props.load_balancer.name)
+          .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
           .and_return(load_balancer)
         allow(azure_client).to receive(:get_application_gateway_by_name)
           .with(vm_props.application_gateway)
@@ -128,7 +128,7 @@ describe Bosh::AzureCloud::VMManager do
     context 'when public ip is not found' do
       before do
         allow(azure_client).to receive(:get_load_balancer_by_name)
-          .with(vm_props.load_balancer.resource_group_name, vm_props.load_balancer.name)
+          .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
           .and_return(load_balancer)
         allow(azure_client).to receive(:get_application_gateway_by_name)
           .with(vm_props.application_gateway)
@@ -190,7 +190,7 @@ describe Bosh::AzureCloud::VMManager do
 
       it 'should raise an error' do
         allow(azure_client).to receive(:get_load_balancer_by_name)
-          .with(vm_props.load_balancer.resource_group_name, vm_props.load_balancer.name)
+          .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
           .and_return(nil)
 
         expect(azure_client).not_to receive(:delete_virtual_machine)
@@ -211,7 +211,7 @@ describe Bosh::AzureCloud::VMManager do
 
       it 'should raise an error' do
         allow(azure_client).to receive(:get_load_balancer_by_name)
-          .with(vm_props.load_balancer.resource_group_name, vm_props.load_balancer.name)
+          .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
           .and_return(load_balancer)
         allow(azure_client).to receive(:get_application_gateway_by_name)
           .with(vm_props.application_gateway)
@@ -231,7 +231,7 @@ describe Bosh::AzureCloud::VMManager do
         allow(azure_client).to receive(:get_network_subnet_by_name)
           .and_return(subnet)
         allow(azure_client).to receive(:get_load_balancer_by_name)
-          .with(vm_props.load_balancer.resource_group_name, vm_props.load_balancer.name)
+          .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
           .and_return(load_balancer)
         allow(azure_client).to receive(:get_application_gateway_by_name)
           .with(vm_props.application_gateway)
@@ -275,7 +275,7 @@ describe Bosh::AzureCloud::VMManager do
           allow(azure_client).to receive(:get_network_subnet_by_name)
             .and_return(subnet)
           allow(azure_client).to receive(:get_load_balancer_by_name)
-            .with(vm_props.load_balancer.resource_group_name, vm_props.load_balancer.name)
+            .with(vm_props.load_balancers.first.resource_group_name, vm_props.load_balancers.first.name)
             .and_return(load_balancer)
           allow(azure_client).to receive(:get_application_gateway_by_name)
             .with(vm_props.application_gateway)

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -111,7 +111,15 @@ shared_context 'shared stuff for vm manager' do
   end
   let(:load_balancer) do
     {
-      name: 'fake-lb-name'
+      name: 'fake-lb-name',
+      backend_address_pools: [
+        {
+          name: 'fake-pool-name',
+          id: 'fake-pool-id',
+          provisioning_state: 'fake-pool-state',
+          backend_ip_configurations: []
+        }
+      ]
     }
   end
   let(:application_gateway) do

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# The following default configurations are shared. If one case needs a specific configuration, it should overwrite it.
+# NOTE: The following default configurations are shared. If one case needs a specific configuration, it should overwrite it.
 shared_context 'shared stuff for vm manager' do
   # Parameters of VMManager.initialize
   let(:azure_config) { mock_azure_config }
@@ -116,7 +116,15 @@ shared_context 'shared stuff for vm manager' do
   end
   let(:application_gateway) do
     {
-      name: 'fake-ag-name'
+      name: 'fake-ag-name',
+      backend_address_pools: [
+        {
+          name: 'fake-pool-name',
+          id: 'fake-pool-id',
+          provisioning_state: 'fake-pool-state',
+          backend_ip_configurations: []
+        }
+      ]
     }
   end
   before do
@@ -128,12 +136,30 @@ shared_context 'shared stuff for vm manager' do
     allow(azure_client).to receive(:get_network_security_group_by_name)
       .with(MOCK_RESOURCE_GROUP_NAME, MOCK_DEFAULT_SECURITY_GROUP)
       .and_return(default_security_group)
+    load_balancer_config = vm_properties['load_balancer']
+    load_balancer_name = load_balancer_config.is_a?(Hash) ? load_balancer_config['name'] : load_balancer_config
+    load_balancer_rg = load_balancer_config.is_a?(Hash) ? load_balancer_config['resource_group_name'] : nil
+    load_balancer_rg ||= MOCK_RESOURCE_GROUP_NAME
     allow(azure_client).to receive(:get_load_balancer_by_name)
-      .with(MOCK_RESOURCE_GROUP_NAME, vm_properties['load_balancer'])
+      .with(load_balancer_rg, load_balancer_name)
       .and_return(load_balancer)
+    application_gateway_config = vm_properties['application_gateway']
+    application_gateway_name = application_gateway_config.is_a?(Hash) ? application_gateway_config['name'] : application_gateway_config
+    application_gateway_rg = application_gateway_config.is_a?(Hash) ? application_gateway_config['resource_group_name'] : nil
     allow(azure_client).to receive(:get_application_gateway_by_name)
-      .with(nil, vm_properties['application_gateway'])
+      .with(application_gateway_rg, application_gateway_name)
       .and_return(application_gateway)
+    # NOTE: If the `:vm_properties` var's `application_gateway/backend_pool_name` doesn't match the `:application_gateway` data's pools,
+    #     then the mock below would be needed to enable usable rspec stack traces.
+    #     Without this mock, the output gives `... received unexpected message :list_network_interfaces_by_keyword with ...`
+    #     which doesn't include the actual error which was raised. Not very useful when debugging spec failures.
+    #     Uncommenting the mock below doesn't SEEM to harm anything,
+    #     even when the spec shared data is correct (and an error like the one mentioned above is NOT raised).
+    #     However, since I'm not CERTAIN it wouldn't cause problems (e.g. if specific specs need a different return value),
+    #     I've left it commented out for now.
+    # allow(azure_client).to receive(:list_network_interfaces_by_keyword)
+    #   .with(MOCK_RESOURCE_GROUP_NAME, vm_name)
+    #   .and_return([]) # .and_return(network_interfaces)
     allow(azure_client).to receive(:get_public_ip_by_name)
       .with(MOCK_RESOURCE_GROUP_NAME, vm_name)
       .and_return(nil)

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -132,7 +132,7 @@ shared_context 'shared stuff for vm manager' do
       .with(MOCK_RESOURCE_GROUP_NAME, vm_properties['load_balancer'])
       .and_return(load_balancer)
     allow(azure_client).to receive(:get_application_gateway_by_name)
-      .with(vm_properties['application_gateway'])
+      .with(nil, vm_properties['application_gateway'])
       .and_return(application_gateway)
     allow(azure_client).to receive(:get_public_ip_by_name)
       .with(MOCK_RESOURCE_GROUP_NAME, vm_name)

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/delete_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/delete_spec.rb
@@ -57,7 +57,7 @@ describe Bosh::AzureCloud::VMManager do
       allow(azure_client).to receive(:get_load_balancer_by_name)
         .with(resource_group_name, vm_name).and_return(load_balancer)
       allow(azure_client).to receive(:get_application_gateway_by_name)
-        .with(vm_name).and_return(application_gateway)
+        .with(nil, vm_name).and_return(application_gateway)
       allow(azure_client).to receive(:get_network_interface_by_name)
         .with(resource_group_name, vm_name).and_return(network_interface)
       allow(azure_client).to receive(:get_public_ip_by_name)


### PR DESCRIPTION
- [x] Please check this box and fill the data as below once you have run the unit tests.
      Code coverage should keeps at 100%. 

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
  popd
  ...
  Finished in 5.25 seconds (files took 0.6538 seconds to load)
  1019 examples, 0 failures, 9 pending
  
  Coverage report generated for RSpec to /Users/justinw/go/src/github.com/cloudfoundry/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage. 4247 / 4266 LOC (99.55%) covered.
  ```

### Testing Notes:

- All of the new code added by this PR is fully covered by unit specs.
- I didn't add integration specs for the new features, since it would involve either modifying the existing integration and BATS assets, or else adding a parallel separate set of such assets.
- The 9 Pending specs are new specs that I added, which relate to existing (long before this PR) uncovered lines of code. I didn't have time to implement these 9, but I figured adding these as pending specs would make it easier fo someone else to get the project back up to 100% coverage.
  * I did add some new specs (which ar unrelated to this PR), to cover some of the pre-existing uncovered lines. The 9 remaining Pending specs are the ones left over.

## Rubocop:

  ```
  bosh_azure_cpi % ./bin/rubocop_check
  ~/go/src/github.com/cloudfoundry/bosh-azure-cpi-release/src/bosh_azure_cpi 
  ~/go/src/github.com/cloudfoundry/bosh-azure-cpi-release/src/bosh_azure_cpi
  Running rubocop with Ruby version ruby-2.7.3...
  ...
  187 files inspected, no offenses detected
  ```

### Rubocop Notes:

- I fixed some pre-existing rubocop offenses (mostly related to layout and formatting).
  * I was going to fix more, but was worried that it would affect so many files it would make this PR hard to code review. _If this PR gets accepted fairly soon, I might have time left to submit additional rubocop fixes as a separate PR._

### Changelog

* Fixes #644.
* Modified the `vm_type/application_gateway` config to allow an Array (of Hashes) to be specified (as an alternative to the currently-supported config data types of String and Hash), to enable multiple AGWs (with independent `vm_type/application_gateway/resource_group_name` or `vm_type/application_gateway/backend_pool_name` values).
* Modified the `vm_type/load_balancer` config to support a new `vm_type/load_balancer/backend_pool_name` sub-property, to allow the config to exlpicitly specify the name of the backend address pool to use. (This change re-establishes/maintains symmetry between the `vm_type/load_balancer` and `vm_type/application_gateway` configs.)
* Modified the `vm_type/load_balancer` config to allow an Array (of Hashes) to be specified, to enable multiple load balancers (with independent `vm_type/load_balancer/resource_group_name` or `vm_type/load_balancer/backend_pool_name` values). (This change re-establishes/maintains symmetry between the `vm_type/load_balancer` and `vm_type/application_gateway` configs.)
* Fixed various missing and inaccurate doc comments.
* Fixed various rubocop offenses.
* Fixed the names/contexts of some existing specs with inaccurate names.
* Added missing specs for previously-uncovered code.
* Upgraded to RSpec from v.5.0 to v3.10.0 (and revendored the gems).
