### PR TITLE
Added `@return` doc comment annotations to methods in `azure_client.rb`.

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -1942,6 +1942,7 @@ module Bosh::AzureCloud
 
     private
 
+    # @return [Hash]
     def _parse_name_from_id(id)
       ret = id.match('/subscriptions/([^/]*)/resourceGroups/([^/]*)/providers/([^/]*)/([^/]*)/([^/]*)(.*)')
       raise AzureError, "\"#{id}\" is not a valid URL." if ret.nil?
@@ -1955,6 +1956,7 @@ module Bosh::AzureCloud
       result
     end
 
+    # @return [Hash, nil]
     def parse_vm_size(result)
       vm_size = nil
       unless result.nil?
@@ -1966,6 +1968,7 @@ module Bosh::AzureCloud
       vm_size
     end
 
+    # @return [Hash, nil]
     def parse_managed_disk(result)
       managed_disk = nil
       unless result.nil?
@@ -1984,6 +1987,7 @@ module Bosh::AzureCloud
       managed_disk
     end
 
+    # @return [Hash, nil]
     def parse_user_image(result)
       user_image = nil
       unless result.nil?
@@ -1998,6 +2002,7 @@ module Bosh::AzureCloud
       user_image
     end
 
+    # @return [Hash, nil]
     def parse_platform_image(result)
       image = nil
       unless result.nil?
@@ -2009,6 +2014,7 @@ module Bosh::AzureCloud
       image
     end
 
+    # @return [Hash, nil]
     def parse_network_interface(result, recursive: true)
       interface = nil
       unless result.nil?
@@ -2083,6 +2089,7 @@ module Bosh::AzureCloud
       interface
     end
 
+    # @return [Hash, nil]
     def parse_subnet(result)
       subnet = nil
       unless result.nil?
@@ -2097,6 +2104,7 @@ module Bosh::AzureCloud
       subnet
     end
 
+    # @return [Hash, nil]
     def parse_public_ip(result)
       ip_address = nil
       unless result.nil?
@@ -2126,6 +2134,7 @@ module Bosh::AzureCloud
       ip_address
     end
 
+    # @return [Hash, nil]
     def parse_storage_account(result)
       storage_account = nil
       unless result.nil?
@@ -2145,6 +2154,7 @@ module Bosh::AzureCloud
       storage_account
     end
 
+    # @return [Boolean]
     def filter_credential_in_logs(uri)
       return true if !is_debug_mode(@azure_config) && uri.request_uri.include?('/listKeys')
 
@@ -2155,16 +2165,19 @@ module Bosh::AzureCloud
       Hash[hash.map { |k, v| [k, v.is_a?(Hash) ? redact_credentials(keys, v) : (keys.include?(k) ? '<redacted>' : v)] }]
     end
 
+    # @return [String]
     def redact_credentials_in_request_body(body)
       is_debug_mode(@azure_config) ? body.to_json : redact_credentials(CREDENTIAL_KEYWORD_LIST, body).to_json
     end
 
+    # @return [Object]
     def redact_credentials_in_response_body(body)
       is_debug_mode(@azure_config) ? body : redact_credentials(CREDENTIAL_KEYWORD_LIST, JSON.parse(body)).to_json
     rescue StandardError => e
       body
     end
 
+    # @return [Net::HTTP]
     def http(uri, use_ssl = true)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true && use_ssl


### PR DESCRIPTION
Background:

There were a few utility methods in `azure_client.rb` called by code related to PR #651 which had no doc comments. And some of those methods' implementations had changed over time so that their method names had become inaccurate. While adding return type annotations to those methods, I noticed many other methods in the same file which also lacked any doc comments and had names which weren't drectly indicative of the type of the value(s) returned, but which weren't directly related to #651.

Since there were also many other un-annotated methods within `azure_client.rb` which also had names which were non-indicative of the return type (thus requiring a maintainer to read each method's implementations to understand what type of value would be returned), I opportunistically added `@return` annotations to many of those methods, assuming that such annotations would be better than completely un-annotated methods. I am submitting these additional annotations as a separate PR since they weren't directly related to the functionality in #651.

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero offenses (after my changes)

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
    ./bin/rubocop_check
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

> 972 examples, 0 failures

Coverage report generated for RSpec to /Users/justinw/go/src/github.com/cloudfoundry/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage. 4182 / 4203 LOC (99.5%) covered.

### Rubocop output:

> 184 files inspected, no offenses detected


# Changelog

* Added `@return` doc comment annotations to methods in `azure_client.rb`.
