### PR TITLE
Fixed the `Bosh::AzureCloud::Cloud.initialize` method's signature so …

### DIFF
--- a/src/bosh_azure_cpi/bin/bosh_azure_console
+++ b/src/bosh_azure_cpi/bin/bosh_azure_console
@@ -26,7 +26,7 @@ end
 
 module ConsoleHelpers
   def cpi
-    @cpi ||= Bosh::AzureCloud::Cloud.new(@config)
+    @cpi ||= Bosh::AzureCloud::Cloud.new(@config, Bosh::AzureCloud::Cloud::CURRENT_API_VERSION)
   end
 
   def registry

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -22,7 +22,7 @@ module Bosh::AzureCloud
     # Cloud initialization
     #
     # @param [Hash] options cloud options
-    def initialize(options, api_version)
+    def initialize(options, api_version = 1)
       options_dup = options.dup.freeze
 
       @api_version = api_version || 1

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -23,9 +23,11 @@ module Bosh::AzureCloud
     #
     # @param [Hash] options cloud options
     def initialize(options, api_version = 1)
+      cloud_error("Invalid api_version '#{api_version}'") unless [1, 2].include?(api_version)
+
       options_dup = options.dup.freeze
 
-      @api_version = api_version || 1
+      @api_version = api_version
 
       @logger = Bosh::Clouds::Config.logger
 

--- a/src/bosh_azure_cpi/spec/manual_tests/performance/performance.rb
+++ b/src/bosh_azure_cpi/spec/manual_tests/performance/performance.rb
@@ -16,7 +16,7 @@ Bosh::Clouds::Config.configure(cloud_config)
 cpi_config_file = File.expand_path('cpi.cfg', __dir__)
 puts cpi_config_file
 config = Psych.load_file(cpi_config_file)
-cpi = Bosh::AzureCloud::Cloud.new(config)
+cpi = Bosh::AzureCloud::Cloud.new(config, Bosh::AzureCloud::Cloud::CURRENT_API_VERSION)
 
 stemcell_id_to_use = nil
 if ARGV[0] == '-i'

--- a/src/bosh_azure_cpi/spec/manual_tests/performance/upload_image.rb
+++ b/src/bosh_azure_cpi/spec/manual_tests/performance/upload_image.rb
@@ -16,7 +16,7 @@ Bosh::Clouds::Config.configure(cloud_config)
 cpi_config_file = File.expand_path('cpi.cfg', __dir__)
 puts cpi_config_file
 config = Psych.load_file(cpi_config_file)
-cpi = Bosh::AzureCloud::Cloud.new(config)
+cpi = Bosh::AzureCloud::Cloud.new(config, Bosh::AzureCloud::Cloud::CURRENT_API_VERSION)
 stemcell_properties = {
   'name' => 'fake-name2',
   'version' => 'fake-version',

--- a/src/bosh_azure_cpi/spec/manual_tests/resource_group_name/helpers.rb
+++ b/src/bosh_azure_cpi/spec/manual_tests/resource_group_name/helpers.rb
@@ -47,7 +47,7 @@ def load_bosh_azure_cpi(cpi_dir, config)
   cloud_config = OpenStruct.new(logger: Logger.new(STDOUT))
   Bosh::Clouds::Config.configure(cloud_config)
 
-  cpi = Bosh::AzureCloud::Cloud.new(config)
+  cpi = Bosh::AzureCloud::Cloud.new(config, Bosh::AzureCloud::Cloud::CURRENT_API_VERSION)
 
   cpi
 end

--- a/src/bosh_azure_cpi/spec/unit/cloud/cloud_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/cloud_spec.rb
@@ -23,12 +23,55 @@ describe Bosh::AzureCloud::Cloud do
     end
 
     context 'api_version' do
-      it 'defaults to api version 1' do
-        expect(cloud.api_version).to eq(1)
+      context 'when not set' do
+        let(:default_api_version) { 1 }
+        let(:cloud) do
+          # NOTE: We can't use `mock_cloud(nil)` here, because that method always explicitly passes both args to the underlying `initialize` method
+          Bosh::AzureCloud::Cloud.new(mock_cloud_options['properties'])
+        end
+
+        it 'defaults to api version 1' do
+          expect(cloud.api_version).to eq(default_api_version)
+        end
       end
 
-      it 'can be set' do
-        expect(cloud_v2.api_version).to eq(2)
+      context 'when explicitly set' do
+        context 'to api version 1' do
+          let(:api_version) { 1 }
+          let(:cloud) { mock_cloud(nil, api_version) }
+
+          it 'succeeds' do
+            expect(cloud.api_version).to eq(api_version)
+          end
+        end
+
+        context 'to api version 2' do
+          let(:api_version) { 2 }
+
+          it 'succeeds' do
+            expect(cloud_v2.api_version).to eq(api_version)
+          end
+        end
+
+        context 'to api version nil' do
+          let(:api_version) { nil }
+
+          it 'raises an exception' do
+            expect do
+              mock_cloud(nil, api_version)
+            end.to raise_error(Bosh::Clouds::CloudError, "Invalid api_version '#{api_version}'")
+          end
+        end
+
+        context 'to api version 3' do
+          let(:api_version) { 3 }
+
+          it 'raises an exception' do
+            expect do
+              mock_cloud(nil, api_version)
+            end.to raise_error(Bosh::Clouds::CloudError, "Invalid api_version '#{api_version}'")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
…that the 2nd argument is optional.

Note: Based on the changes made in commit 6c6ec5909b3635d5ea14a5f4dfa2263f2edf1468 (which added the 2nd argument), it seems that the argument was intended to be optional from the start. However, according to the method's signature, it was technically a required argument (despite that the method handles nil/missing values internally on line 29). Also, the following code already doesn't pass the 2nd argument:
- https://github.com/cloudfoundry/bosh-azure-cpi-release/blob/9754cf84f18be7ce0250518bd5a660a459470b56/src/bosh_azure_cpi/bin/bosh_azure_console#L29

Note: The separate handling of the argument's default value on lines 26 and 29 are not redundant. The default value in the signature (line 26) only applies when the optional arg is omitted by the caller. If the caller explicitly specifies the argument with a value of `nil`, the arg default doesn't override the nil, but the `|| 1` on line 29 will. And without the argument default on line 26, the argument technically isn't optional, it is required. Meaning that it is technically an error for any caller to omit that argument, and that line 29 would therefore be covering up the caller's misuse of the method. So both "defaults" are needed in order to correctly handle all of the possible method invocation options for that argument.

Here is the error message which was previously being detected (prior to this change):
> Missing argument 'api_version'. Required 2, 'options, api_version'

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ N/A ] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero offenses (after my changes)

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
    ./bin/rubocop_check
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

> 972 examples, 0 failures
> Coverage report generated for RSpec to /Users/justinw/go/src/github.com/cloudfoundry/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage. 4182 / 4203 LOC (99.5%) covered.

### Rubocop output:

> 184 files inspected, no offenses detected

# Changelog

* Changed the `Bosh::AzureCloud::Cloud.initialize` method's signature to make the 2nd positional argument explicitly optional