### PR TITLE
Implement API method resize_disk for managed disks

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -448,7 +448,36 @@ module Bosh::AzureCloud
     #
     def resize_disk(disk_cid, new_size)
       @logger.info("resize_disk(#{disk_cid}, #{new_size})")
-      raise Bosh::Clouds::NotSupported
+      raise Bosh::Clouds::NotSupported unless @use_managed_disks
+
+      @telemetry_manager.monitor('initialize') do
+        _init_azure
+      end
+
+      extras = { 'disk_size' => new_size }
+      with_thread_name("resize_disk(#{disk_cid}, #{new_size})") do
+        @telemetry_manager.monitor('resize_disk', id: disk_cid, extras: extras) do
+          # Azure API wants disk sizes in GiBs
+          new_size_in_gib = mib_to_gib(new_size)
+          disk_id = DiskId.parse(disk_cid, _azure_config.resource_group_name)
+          disk_name = disk_id.disk_name
+          disk = @disk_manager2.get_data_disk(disk_id)
+          old_size_in_gib = disk[:disk_size]
+          if new_size_in_gib < old_size_in_gib
+            # fall back to creating a new disk and copying data
+            raise Bosh::Clouds::NotSupported
+          elsif new_size_in_gib == old_size_in_gib
+            @logger.info("Skip resize of disk '#{disk_name}' because the new size of #{new_size_in_gib} GiB matches the actual disk size")
+          else
+            @logger.info("Start resize of disk '#{disk_name}' from #{old_size_in_gib} GiB to #{new_size_in_gib} GiB")
+            @disk_manager2.resize_disk(disk_id, new_size_in_gib)
+          end
+        end
+      end
+    end
+
+    def mib_to_gib(size)
+      (size / 1024.0).ceil
     end
 
     ##

--- a/src/bosh_azure_cpi/lib/cloud/azure/disk/disk_manager2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/disk/disk_manager2.rb
@@ -64,6 +64,19 @@ module Bosh::AzureCloud
       @azure_client.create_managed_disk_from_blob(resource_group_name, disk_params)
     end
 
+    def resize_disk(disk_id, new_size)
+      @logger.info("resize_disk(#{disk_id}, #{new_size})")
+      resource_group_name = disk_id.resource_group_name
+      disk_name = disk_id.disk_name
+      disk_params = {
+        name: disk_name,
+        disk_size: new_size
+      }
+
+      @logger.info("Start resize of disk '#{disk_name}' to #{new_size} GiB")
+      @azure_client.resize_managed_disk(resource_group_name, disk_params)
+    end
+
     def delete_disk(resource_group_name, disk_name)
       @logger.info("delete_disk(#{resource_group_name}, #{disk_name})")
       retried = false

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -886,6 +886,16 @@ module Bosh::AzureCloud
       http_put(url, disk)
     end
 
+    def resize_managed_disk(resource_group_name, params)
+      url = rest_api_url(REST_API_PROVIDER_COMPUTE, REST_API_DISKS, resource_group_name: resource_group_name, name: params[:name])
+      disk = {
+        'properties' => {
+          'diskSizeGB' => params[:disk_size]
+        }
+      }
+      http_patch(url, disk)
+    end
+
     # Create a managed disk from storage blob SAS URI (import).
     #
     # ==== Attributes

--- a/src/bosh_azure_cpi/spec/integration/managed_disks_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/managed_disks_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'integration/spec_helper'
+
+describe Bosh::AzureCloud::Cloud do
+  subject(:cpi_managed) do
+    cloud_options_managed = @cloud_options.dup
+    cloud_options_managed['azure']['use_managed_disks'] = true
+    described_class.new(cloud_options_managed, Bosh::AzureCloud::Cloud::CURRENT_API_VERSION)
+  end
+
+  let(:size) { 10_000 }
+  let(:new_size) { 20_000 }
+
+  before { @disk_id_pool = [] }
+
+  after do
+    @disk_id_pool.each do |disk_id|
+      @logger.info("Cleanup: Deleting the disk '#{disk_id}'")
+      cpi_managed.delete_disk(disk_id) if disk_id
+    end
+  end
+
+  context 'Resize a disk to a higher size' do
+    it 'should work' do
+      @logger.info("Create new managed disk with #{size} MiB")
+      disk_cid = cpi_managed.create_disk(size, {})
+      expect(disk_cid).not_to be_nil
+      @disk_id_pool.push(disk_cid)
+
+      @logger.info("Resize managed disk '#{disk_cid}' to #{new_size} MiB")
+      cpi_managed.resize_disk(disk_cid, new_size)
+
+      disk_id_obj = Bosh::AzureCloud::DiskId.parse(disk_cid, @azure_config.resource_group_name)
+      disk = get_azure_client.get_managed_disk_by_name(@default_resource_group_name, disk_id_obj.disk_name)
+      expect(disk[:disk_size]).to eq(cpi_managed.mib_to_gib(new_size))
+
+      @logger.info("Delete managed disk '#{disk_cid}'")
+      cpi_managed.delete_disk(disk_cid)
+      @disk_id_pool.delete(disk_cid)
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/azure_client/managed_disks_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/managed_disks_spec.rb
@@ -510,4 +510,106 @@ describe Bosh::AzureCloud::AzureClient do
       end
     end
   end
+
+  describe '#resize_managed_disk' do
+    let(:disk_uri) { "https://management.azure.com/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Compute/disks/#{disk_name}?api-version=#{api_version_compute}" }
+    let(:disk_params) do
+      {
+        name: disk_name,
+        disk_size: 1000
+      }
+    end
+
+    let(:request_body) do
+      {
+        properties: {
+          diskSizeGB: 1000
+        }
+      }
+    end
+
+    context 'when the response immediately says the disk is updated' do
+      it 'should work' do
+        stub_request(:post, token_uri).to_return(
+          status: 200,
+          body: {
+            'access_token' => valid_access_token,
+            'expires_on' => expires_on
+          }.to_json,
+          headers: {}
+        )
+        stub_request(:patch, disk_uri).with(body: request_body).to_return(
+          status: 200,
+          body: '',
+          headers: {}
+        )
+
+        expect do
+          azure_client.resize_managed_disk(resource_group, disk_params)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when the response says the disk is still updating' do
+      it 'should work' do
+        stub_request(:post, token_uri).to_return(
+          status: 200,
+          body: {
+            'access_token' => valid_access_token,
+            'expires_on' => expires_on
+          }.to_json,
+          headers: {}
+        )
+        stub_request(:patch, disk_uri).to_return(
+          status: 202,
+          body: '{}',
+          headers: {
+            'azure-asyncoperation' => operation_status_link
+          }
+        )
+        stub_request(:get, operation_status_link).to_return(
+          status: 200,
+          body: '{"status":"Succeeded"}',
+          headers: {
+            'Retry-After' => '1'
+          }
+        )
+
+        expect do
+          azure_client.resize_managed_disk(resource_group, disk_params)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when the request failed' do
+      it 'should raise an exception' do
+        stub_request(:post, token_uri).to_return(
+          status: 200,
+          body: {
+            'access_token' => valid_access_token,
+            'expires_on' => expires_on
+          }.to_json,
+          headers: {}
+        )
+        stub_request(:patch, disk_uri).to_return(
+          status: 202,
+          body: '{}',
+          headers: {
+            'azure-asyncoperation' => operation_status_link
+          }
+        )
+        stub_request(:get, operation_status_link).to_return(
+          status: 200,
+          body: '{"status":"Failed"}',
+          headers: {
+            'Retry-After' => '1'
+          }
+        )
+
+        expect do
+          azure_client.resize_managed_disk(resource_group, disk_params)
+        end.to raise_error /check_completion - http code: 200/
+      end
+    end
+  end
 end

--- a/src/bosh_azure_cpi/spec/unit/cloud/resize_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/resize_disk_spec.rb
@@ -7,13 +7,72 @@ describe Bosh::AzureCloud::Cloud do
   include_context 'shared stuff'
 
   describe '#resize_disk' do
-    let(:vm_cid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
-    let(:new_size) { double('size') }
+    let(:disk_cid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
+    let(:new_size) { 1_024_000 }
+    let(:disk_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
+    let(:resource_group_name) { 'fake-resource-group-name' }
+    let(:disk_name) { 'fake-disk-name' }
 
-    it 'should raise a NotSupported error' do
+    before do
+      allow(Bosh::AzureCloud::DiskId).to receive(:parse)
+        .and_return(disk_id_object)
+      allow(disk_id_object).to receive(:resource_group_name)
+        .and_return(resource_group_name)
+      allow(disk_id_object).to receive(:disk_name)
+        .and_return(disk_name)
+      allow(disk_manager2).to receive(:get_data_disk)
+        .and_return({ disk_size: 512 })
+      allow(telemetry_manager).to receive(:monitor)
+        .with('resize_disk', id: disk_cid, extras: { 'disk_size' => new_size })
+        .and_call_original
+      allow(Bosh::Clouds::Config.logger).to receive(:info)
+    end
+
+    it 'should raise a NotSupported error if use_managed_disks is false' do
       expect do
-        cloud.resize_disk(vm_cid, new_size)
+        cloud.resize_disk(disk_cid, new_size)
       end.to raise_error(Bosh::Clouds::NotSupported)
+    end
+
+    context 'when trying to resize to a larger disk size multiple of 1024' do
+      let(:new_size) { 1_024_000 }
+      it 'should work' do
+        expect(disk_manager2).to receive(:resize_disk).with(disk_id_object, 1000)
+        expect(Bosh::Clouds::Config.logger).to receive(:info).with("Start resize of disk 'fake-disk-name' from 512 GiB to 1000 GiB")
+        expect do
+          managed_cloud.resize_disk(disk_cid, new_size)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when trying to resize to a larger disk size not multiple of 1024' do
+      let(:new_size) { 1_024_100 }
+      it 'should work' do
+        expect(disk_manager2).to receive(:resize_disk).with(disk_id_object, 1001)
+        expect(Bosh::Clouds::Config.logger).to receive(:info).with("Start resize of disk 'fake-disk-name' from 512 GiB to 1001 GiB")
+        expect do
+          managed_cloud.resize_disk(disk_cid, new_size)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when trying to resize to the same disk size' do
+      let(:new_size) { 512 * 1024 }
+      it 'should work' do
+        expect(Bosh::Clouds::Config.logger).to receive(:info).with("Skip resize of disk 'fake-disk-name' because the new size of 512 GiB matches the actual disk size")
+        expect do
+          managed_cloud.resize_disk(disk_cid, new_size)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when trying to resize to a smaller disk size' do
+      let(:new_size) { 256_000 }
+      it 'should raise a NotSupported error' do
+        expect do
+          managed_cloud.resize_disk(disk_cid, new_size)
+        end.to raise_error(Bosh::Clouds::NotSupported)
+      end
     end
   end
 end

--- a/src/bosh_azure_cpi/spec/unit/disk_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/disk_manager2_spec.rb
@@ -90,6 +90,39 @@ describe Bosh::AzureCloud::DiskManager2 do
     end
   end
 
+  describe '#resize_disk' do
+    let(:new_size) { 1000 }
+    let(:disk_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
+    let(:resource_group_name) { 'fake-resource-group-name' }
+    let(:disk_name) { 'fake-disk-name' }
+    let(:disk_params) do
+      {
+        name: 'fake-disk-name',
+        disk_size: 1000
+      }
+    end
+
+    before do
+      allow(Bosh::AzureCloud::DiskId).to receive(:parse)
+        .and_return(disk_id_object)
+      allow(disk_id_object).to receive(:resource_group_name)
+        .and_return(resource_group_name)
+      allow(disk_id_object).to receive(:disk_name)
+        .and_return(disk_name)
+      allow(Bosh::Clouds::Config.logger).to receive(:info)
+    end
+
+    it 'resizes the managed disk' do
+      expect(azure_client).to receive(:resize_managed_disk)
+        .with(resource_group_name, disk_params)
+      expect(Bosh::Clouds::Config.logger).to receive(:info)
+        .with("Start resize of disk 'fake-disk-name' to 1000 GiB")
+      expect do
+        disk_manager2.resize_disk(disk_id, new_size)
+      end.not_to raise_error
+    end
+  end
+
   describe '#delete_disk' do
     context 'when the disk exists' do
       before do


### PR DESCRIPTION
# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero offenses (after my changes)

### Unit Test output:

```
Finished in 12.4 seconds (files took 1.2 seconds to load)
1020 examples, 0 failures

Coverage report generated for RSpec to /root/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage. 4277 / 4296 LOC (99.56%) covered.
~/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi
```

### Rubocop output:

```
Offenses:

lib/cloud/azure/restapi/azure_client.rb:25:3: C: Metrics/ClassLength: Class has too many lines. [1664/1645]
  class AzureClient ...
  ^^^^^^^^^^^^^^^^^
spec/unit/azure_client/get_operation_spec.rb:8:1: C: Metrics/BlockLength: Block has too many lines. [2219/2197]
describe Bosh::AzureCloud::AzureClient do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

187 files inspected, 2 offenses detected
```

# Changelog

* This change allows to resize managed disks on Azure.
* Downsizing is not supported by Azure so in this case we still fall back to the strategy of creating a new disk and copying data.
* Analogous change to: https://github.com/cloudfoundry/bosh-aws-cpi-release/commit/91a701e150b02c31fd1887e217fb5e7c09744cb3 and https://github.com/cloudfoundry/bosh-openstack-cpi-release/commit/d081938852ecae502c0ba285020996a4a0c0d01d
