### PR TITLE
Monkey Patch: URI.escape

### DIFF
--- a/src/bosh_azure_cpi/lib/bosh_azure_cpi.rb
+++ b/src/bosh_azure_cpi/lib/bosh_azure_cpi.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
 require 'cloud/azure'
+
+require 'monkey_patches/uri_monkey_patch'
+Bosh::AzureCloud::URIMonkeyPatch.apply_patch

--- a/src/bosh_azure_cpi/lib/monkey_patches/uri_monkey_patch.rb
+++ b/src/bosh_azure_cpi/lib/monkey_patches/uri_monkey_patch.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module Bosh::AzureCloud
+  module URIMonkeyPatch
+    AZURE_STORAGE_TARGET_VERSION = '2.0.4'
+
+    AZURE_VERSION_MISMATCH_WARNING = "This monkey patch is intended for Azure Storage Table Version #{AZURE_STORAGE_TARGET_VERSION} Please review if the patch is needed in the new version.".freeze
+
+    def self.apply_patch
+      raise AZURE_VERSION_MISMATCH_WARNING unless azure_storage_table_version_ok?
+      return if ::URI.method_defined?(:escape)
+
+      ::URI.class_eval do
+        def self.escape(*args)
+          URI.encode_www_form_component(*args)
+        end
+      end
+    end
+
+    def self.azure_storage_table_version_ok?
+      Azure::Storage::Table::Version.to_s == AZURE_STORAGE_TARGET_VERSION
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/monkey_patches/uri_monkey_patch_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/monkey_patches/uri_monkey_patch_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'monkey_patches/uri_monkey_patch'
+describe Bosh::AzureCloud::URIMonkeyPatch do
+  describe '.apply_patch' do
+    context 'when URI does not have an escape method' do
+      it 'should add the escape function' do
+        expect { URI.method(:escape) }.to raise_error(NameError)
+        expect { Bosh::AzureCloud::URIMonkeyPatch.apply_patch }.not_to raise_error
+        expect { URI.method(:escape) }.not_to raise_error
+      end
+
+      context 'and azure-storage-table library is not 2.0.4' do
+        let(:mismatch_version) { '2.0.5' }
+
+        before do
+          allow(::Azure::Storage::Table::Version).to receive(:to_s).and_return(mismatch_version)
+        end
+
+        it 'should raise an exception' do
+          expect { Bosh::AzureCloud::URIMonkeyPatch.apply_patch }.to raise_error(Bosh::AzureCloud::URIMonkeyPatch::AZURE_VERSION_MISMATCH_WARNING)
+        end
+      end
+    end
+
+    context 'when URI has an escape method' do
+      before do
+        allow(::URI).to receive(:method_defined?).with(:escape).and_return(true)
+      end
+
+      it 'should not modify the current escape method' do
+        allow(URI).to receive(:class_eval)
+
+        expect { Bosh::AzureCloud::URIMonkeyPatch.apply_patch }.not_to raise_error
+        expect(URI).not_to receive(:class_eval)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related to problems in the bump to ruby 3.1 .  From ruby 3 URI.escape function was removed. This is
a monkey patch to add that function again and restore the broken functionality.

[#181531703] [azure cpi] Fix the Docker image that builds the azure CPI

Signed-off-by: Daniel Felipe Ochoa <danielfelipo@vmware.com>

--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

Thanks for submitting a pull request!

All pull request submitters and commit authors must have a Contributor License Agreement (CLA) on-file with us. Please sign the appropriate CLA ([individual](http://cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf) or [corporate](http://cloudfoundry.org/pdfs/CFF_Corporate_CLA.pdf)).

When sending signed CLA please provide your github username in case of individual CLA or the list of github usernames that can make pull requests on behalf of your organization.

If you are confident that you're covered under a Corporate CLA, please make sure you've publicized your membership in the appropriate Github Org, per [these instructions](https://help.github.com/articles/publicizing-or-concealing-organization-membership/).

--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero offenses (after my changes)

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
    ./bin/rubocop_check
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

> Finished in 8.26 seconds (files took 1.57 seconds to load)
> 1023 examples, 0 failures
> 
> Coverage report generated for RSpec to /Users/danielfelipo/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage. 4275 / 4295 LOC (99.53%) covered.


### Rubocop output:

4 offenses reside in files that were not modified in this PR.

> 190 files inspected, 4 offenses detected, 4 offenses auto-correctable
> rubocop find some issues.
> ~/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi


# Changelog

* Monkey patch that adds URI.escape function , to patch ruby 3.1 std library.
