### PR TITLE
Fix broken offline environment create-env

### DIFF
--- a/packages/bosh_azure_cpi/packaging
+++ b/packages/bosh_azure_cpi/packaging
@@ -10,7 +10,10 @@ cp -a bosh_azure_cpi/* "${BOSH_INSTALL_TARGET}"
 
 cd "${BOSH_INSTALL_TARGET}"
 
-BUNDLE_DEPLOYMENT="true" \
-BUNDLE_CACHE_PATH="vendor/package" \
-BUNDLE_WITHOUT="development:test" \
-bundle install --local
+BUNDLE_CACHE_PATH="vendor/package"
+
+bundle config set --local deployment 'true'
+bundle config set --local no_prune 'true'
+bundle config set --local without 'development test'
+
+bundle install


### PR DESCRIPTION
bundler stopped picking up some cli flags and some env vars. there have
been warnings around this but we do not see them when the create-env
succeeds. It wasn't caught in CI since the CI environment is not
internetless. So bundler was still able to reach out to get the
gems that were already present locally (which it ignored because it
ignored the cli flags)

Signed-off-by: jpalermo <jpalermo@vmware.com>