### PR TITLE
fix VM create error caused by VM image not ready

### DIFF
--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager2_spec.rb
@@ -218,6 +218,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
             it 'should get the stemcell from the default storage account, create a new user image and return the user image information' do
               expect(azure_client).not_to receive(:list_storage_accounts)
               expect(stemcell_manager2).to receive(:flock).with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX).and_call_original
+              expect(stemcell_manager2).to receive(:flock).with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX).and_call_original
               expect(azure_client).to receive(:create_user_image)
               stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
               expect(stemcell_info.uri).to eq(user_image_id)
@@ -234,6 +235,7 @@ describe Bosh::AzureCloud::StemcellManager2 do
 
             it 'should get the stemcell from the default storage account, get the user image and return image information' do
               expect(azure_client).not_to receive(:list_storage_accounts)
+              expect(stemcell_manager2).to receive(:flock).with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX).and_call_original
               expect(stemcell_manager2).to receive(:flock).with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX).and_call_original
               expect(azure_client).not_to receive(:create_user_image)
               stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
@@ -298,6 +300,9 @@ describe Bosh::AzureCloud::StemcellManager2 do
                 expect(stemcell_manager2).to receive(:flock)
                   .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
                   .and_call_original
+                expect(stemcell_manager2).to receive(:flock)
+                  .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
+                  .and_call_original
                 expect(azure_client).to receive(:create_user_image)
                 stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
                 expect(stemcell_info.uri).to eq(user_image_id)
@@ -329,6 +334,9 @@ describe Bosh::AzureCloud::StemcellManager2 do
                   expect(stemcell_manager2).to receive(:flock)
                     .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
                     .and_call_original
+                  expect(stemcell_manager2).to receive(:flock)
+                    .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
+                    .and_call_original
                   expect(blob_manager).to receive(:copy_blob)
                     .with(existing_storage_account_name, stemcell_container, "#{stemcell_name}.vhd", stemcell_blob_uri)
                   expect(azure_client).to receive(:create_user_image)
@@ -349,6 +357,9 @@ describe Bosh::AzureCloud::StemcellManager2 do
                 end
 
                 it 'should raise an error' do
+                  expect(stemcell_manager2).to receive(:flock)
+                    .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
+                    .and_call_original
                   expect(stemcell_manager2).to receive(:flock)
                     .with("#{CPI_LOCK_COPY_STEMCELL}-#{stemcell_name}-#{existing_storage_account_name}", File::LOCK_EX)
                     .and_call_original
@@ -425,6 +436,9 @@ describe Bosh::AzureCloud::StemcellManager2 do
                 expect(stemcell_manager2).to receive(:flock)
                   .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
                   .and_call_original
+                expect(stemcell_manager2).to receive(:flock)
+                  .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
+                  .and_call_original
                 expect(blob_manager).to receive(:copy_blob)
                 expect(azure_client).to receive(:create_user_image)
                 stemcell_info = stemcell_manager2.get_user_image_info(stemcell_name, storage_account_type, location)
@@ -468,6 +482,9 @@ describe Bosh::AzureCloud::StemcellManager2 do
               expect(stemcell_manager2).to receive(:flock)
                 .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
                 .and_call_original
+              expect(stemcell_manager2).to receive(:flock)
+                .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
+                .and_call_original
               expect(azure_client).to receive(:create_user_image)
 
               expect do
@@ -495,6 +512,9 @@ describe Bosh::AzureCloud::StemcellManager2 do
             end
 
             it 'should return the new user image' do
+              expect(stemcell_manager2).to receive(:flock)
+                .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
+                .and_call_original
               expect(stemcell_manager2).to receive(:flock)
                 .with("#{CPI_LOCK_CREATE_USER_IMAGE}-#{user_image_name}", File::LOCK_EX)
                 .and_call_original


### PR DESCRIPTION
If two VM create operations are running at the same time, one of them might fail because it tries to use a VM image that is still being created:

P1 -> check image -> does not exist -> create VM image -> wait for VM image operation to finish -> once finished VM create
P2 -> check image -> exists (in creating state from P1) -> VM create -> fails with OperationNotAllowed

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero offenses (after my changes)

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
    ./bin/rubocop_check
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

Finished in 9.73 seconds (files took 0.84091 seconds to load)
1030 examples, 0 failures

Coverage report generated for RSpec to /workspaces/dev_bosh-azure-cpi-release/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage. 4225 / 4248 LOC (99.46%) covered.

### Rubocop output:

191 files inspected, 412 offenses detected, 405 offenses autocorrectable
rubocop find some issues.

# Changelog

* Fix OperationNotAllowed error
