### PR TITLE
Allow Azure CPI to continue to work on Xenial stemcells.

### DIFF
--- a/packages/bosh_azure_cpi/packaging
+++ b/packages/bosh_azure_cpi/packaging
@@ -10,6 +10,7 @@ cp -a bosh_azure_cpi/* "${BOSH_INSTALL_TARGET}"
 
 cd "${BOSH_INSTALL_TARGET}"
 
+
 export BUNDLER_VERSION="$(bundle -v | grep -o -e '[0-9.]*')"
 bundle config set --local deployment 'true'
 bundle config set --local no_prune 'true'

--- a/src/bosh_azure_cpi/Gemfile
+++ b/src/bosh_azure_cpi/Gemfile
@@ -12,7 +12,8 @@ gem 'jwt',              '~> 2.2', '>= 2.2.2'
 gem 'deep_merge',       '~> 1.2', '>= 1.2.1'
 gem 'net-smtp'
 
-gem 'fast_jsonparser', '~> 0.6.0'
+#fast_jsonparser has a GCC requirement that cannot be guaranteed by all VMs the CPI might run on.
+gem 'fast_jsonparser', '~> 0.6.0', :install_if => `gcc -dumpversion`.to_i > 6
 gem 'rspec-retry', group: :test
 
 group :development, :test do

--- a/src/bosh_azure_cpi/lib/cloud/azure.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure.rb
@@ -12,7 +12,14 @@ require 'etc'
 require 'fcntl'
 require 'fileutils'
 require 'logging'
-require 'fast_jsonparser'
+
+begin
+  require 'fast_jsonparser'
+rescue LoadError
+  require 'monkey_patches/fast_json_monkey_patch'
+  Bosh::AzureCloud::FastJsonMonkeyPatch.apply_patch
+end
+
 require 'jwt'
 require 'open3'
 require 'pp'

--- a/src/bosh_azure_cpi/lib/monkey_patches/fast_json_monkey_patch.rb
+++ b/src/bosh_azure_cpi/lib/monkey_patches/fast_json_monkey_patch.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# Note this will be removed when xenial with ESM is out of support
+# @TODO remove when xenial is no longer supported
+
+module Bosh::AzureCloud
+  module FastJsonMonkeyPatch
+    def self.apply_patch
+      require 'json'
+      fast_json_facade = Class.new do
+        def self.parse(*args)
+          JSON.parse(*args)
+        end
+
+        def self.load(*args)
+          JSON.load_file(*args)
+        end
+      end
+      Object.const_set(:FastJsonparser, fast_json_facade)
+    end
+  end
+end


### PR DESCRIPTION
FastJsonParser, which was recently added to speed up JSON parsing is
incompatible with older gcc's such as those found on the Xenial
stemcell. This commit allows platforms that do not have a modern enough
GCC to fall back to "slow" JSON parsing.