### PR TITLE
Remove blobstore info from IaaS metadata endpoints

### DIFF
--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -116,52 +116,10 @@ properties:
     description: List of ntp server IPs. pool.ntp.org attempts to return IPs closest to your location, but you can still specify if needed.
     default: [0.pool.ntp.org, 1.pool.ntp.org]
 
-  blobstore.provider:
-    description: Provider of the blobstore used by director and agent (dav|simple|s3)
-    default: 'dav'
-  blobstore.bucket_name:
-    description: AWS S3 Bucket used by s3 blobstore plugin
-  blobstore.access_key_id:
-    description: AWS access_key_id used by s3 blobstore plugin
-  blobstore.secret_access_key:
-    description: AWS secret_access_key used by s3 blobstore plugin
-  blobstore.use_ssl:
-    description: Whether the simple blobstore plugin should use SSL to connect to the blobstore server
-    default: true
-  blobstore.s3_port:
-    description: Port of blobstore server used by s3 blobstore plugin
-    default: 443
-  blobstore.host:
-    description: Host of blobstore server used by simple blobstore plugin
-  blobstore.s3_force_path_style:
-    description: Whether s3 blobstore plugin will always use path style for bucket access
-    default: false
-  blobstore.path:
-    description: local blobstore path
-  blobstore.address:
-    description: Address of blobstore server used by simple blobstore plugin
-  blobstore.port:
-    description: Port of blobstore server used by simple blobstore plugin
-    default: 25250
-  blobstore.agent.user:
-    description: |
-      Username agent uses to connect to blobstore used by simple blobstore
-      plugin (Optional)
-  blobstore.agent.password:
-    description: |
-      Password agent uses to connect to blobstore used by simple blobstore
-      plugin (Required only when user is provided)
-
-  agent.blobstore.secret_access_key:
-    description: AWS secret_access_key for agent used by s3 blobstore plugin
   agent.mbus:
     description: Agent mbus
   agent.nats.address:
     description: Address of the nats server
-  agent.blobstore.address:
-    description: Address for agent to connect to blobstore server used by simple blobstore plugin
-  agent.blobstore.access_key_id:
-    description: AWS access_key_id for agent used by s3 blobstore plugin
 
   nats.user:
     description: Username to connect to nats with

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -107,41 +107,6 @@
     params['cloud']['properties']['azure']['isv_tracking_guid'] = isv_tracking_guid
   end
 
-  if_p('blobstore') do
-    blobstore_params = {
-      'provider' => p('blobstore.provider')
-    }
-    if p('blobstore.provider') == 's3'
-      options_params = {
-        'bucket_name' => p('blobstore.bucket_name'),
-        'access_key_id' => p(['agent.blobstore.access_key_id', 'blobstore.access_key_id']),
-        'secret_access_key' => p(['agent.blobstore.secret_access_key', 'blobstore.secret_access_key'])
-      }
-      def update_blobstore_options(options, manifest_key, rendered_key=manifest_key)
-        value = p(["agent.blobstore.#{manifest_key}", "blobstore.#{manifest_key}"], nil)
-        options[rendered_key] = value unless value.nil?
-      end
-      update_blobstore_options(options_params, 'use_ssl')
-      update_blobstore_options(options_params, 's3_port', 'port')
-      update_blobstore_options(options_params, 'host')
-      update_blobstore_options(options_params, 's3_force_path_style')
-    elsif p('blobstore.provider') == 'local'
-      options_params = {
-        'blobstore_path' => p('blobstore.path')
-      }
-    else
-      options_params = {
-        'endpoint' => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}"
-      }
-
-      if_p('blobstore.agent.user') do
-        options_params["user"] = p('blobstore.agent.user')
-        options_params["password"] = p('blobstore.agent.password')
-      end
-    end
-    blobstore_params['options'] = options_params
-    params['cloud']['properties']['agent']['blobstore'] = blobstore_params
-  end
   if_p('agent.mbus') do |mbus|
     params['cloud']['properties']['agent']['mbus'] = mbus
   end.else_if_p('nats') do

--- a/src/bosh_azure_cpi/spec/spec_helper.rb
+++ b/src/bosh_azure_cpi/spec/spec_helper.rb
@@ -81,9 +81,6 @@ def mock_cloud_options
         'password' => 'admin'
       },
       'agent' => {
-        'blobstore' => {
-          'address' => '10.0.0.5'
-        },
         'nats' => {
           'address' => '10.0.0.5'
         }

--- a/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -29,13 +29,6 @@ describe 'cpi.json.erb' do
           'password' => 'admin',
           'port' => 25_777
         },
-        'blobstore' => {
-          'address' => 'blobstore-address.example.com',
-          'agent' => {
-            'user' => 'agent',
-            'password' => 'agent-password'
-          }
-        },
         'nats' => {
           'address' => 'nats-address.example.com',
           'password' => 'nats-password'
@@ -89,14 +82,6 @@ describe 'cpi.json.erb' do
               '0.pool.ntp.org',
               '1.pool.ntp.org'
             ],
-            'blobstore' => {
-              'provider' => 'dav',
-              'options' => {
-                'endpoint' => 'http://blobstore-address.example.com:25250',
-                'user' => 'agent',
-                'password' => 'agent-password'
-              }
-            },
             'mbus' => 'nats://nats:nats-password@nats-address.example.com:4222'
           }
         }
@@ -489,13 +474,6 @@ describe 'cpi.json.erb' do
               'ssh_public_key' => 'ssh-rsa ABCDEFGHIJKLMN',
               'default_security_group' => 'fake-default-security-group'
             },
-            'blobstore' => {
-              'address' => 'blobstore-address.example.com',
-              'agent' => {
-                'user' => 'agent',
-                'password' => 'agent-password'
-              }
-            },
             'nats' => {
               'address' => 'nats-address.example.com',
               'password' => 'nats-password'
@@ -506,88 +484,6 @@ describe 'cpi.json.erb' do
 
       it 'should not include registry settings in json' do
         expect(subject['cloud']['properties'].key?('registry')).to be_falsy
-      end
-    end
-  end
-
-  context 'when parsing the agent property' do
-    let(:rendered_blobstore) { subject['cloud']['properties']['agent']['blobstore'] }
-
-    context 'when using an s3 blobstore' do
-      context 'when provided a minimal configuration' do
-        before do
-          manifest['properties']['blobstore'].merge!(
-            'provider' => 's3',
-            'bucket_name' => 'my_bucket',
-            'access_key_id' => 'blobstore-access-key-id',
-            'secret_access_key' => 'blobstore-secret-access-key'
-          )
-        end
-
-        it 'renders the s3 provider section with the correct defaults' do
-          expect(rendered_blobstore).to eq(
-            'provider' => 's3',
-            'options' => {
-              'bucket_name' => 'my_bucket',
-              'access_key_id' => 'blobstore-access-key-id',
-              'secret_access_key' => 'blobstore-secret-access-key',
-              'use_ssl' => true,
-              'port' => 443,
-              's3_force_path_style' => false
-            }
-          )
-        end
-      end
-    end
-
-    context 'when using a local blobstore' do
-      context 'when provided a minimal configuration' do
-        before do
-          manifest['properties']['blobstore'].merge!(
-            'provider' => 'local',
-            'path' => '/fake/path'
-          )
-        end
-
-        it 'renders the local provider section with the correct defaults' do
-          expect(rendered_blobstore).to eq(
-            'provider' => 'local',
-            'options' => {
-              'blobstore_path' => '/fake/path'
-            }
-          )
-        end
-      end
-
-      context 'when provided an incomplete configuration' do
-        before do
-          manifest['properties']['blobstore'].merge!(
-            'provider' => 'local'
-          )
-        end
-
-        it 'raises an error' do
-          expect { rendered_blobstore }.to raise_error(/Can't find property 'blobstore.path'/)
-        end
-      end
-    end
-
-    context 'when using a dav blobstore' do
-      it 'renders agent user/password for accessing blobstore' do
-        expect(rendered_blobstore['options']['user']).to eq('agent')
-        expect(rendered_blobstore['options']['password']).to eq('agent-password')
-      end
-
-      context 'when enabling signed URLs' do
-        before do
-          manifest['properties']['blobstore']['agent'].delete('user')
-          manifest['properties']['blobstore']['agent'].delete('password')
-        end
-
-        it 'does not render agent user/password for accessing blobstore' do
-          expect(rendered_blobstore['options']['user']).to be_nil
-          expect(rendered_blobstore['options']['password']).to be_nil
-        end
       end
     end
   end


### PR DESCRIPTION
The BOSH agent reads its blobstore settings from the metadata API endpoint (or equivalent) for its VM within the IaaS. If the blobstore settings are not set in the `env.bosh.blobstores` property, it will fallback to the top-level `blobstore` property in the metadata.

However, in modern configurations, the Director always sends the blobstore settings as part of the environment hash. Additionally, the Director does redaction of credentials in the environment hash when the signed URLs blobstore feature is enabled. This redaction is not applied to the top-level `blobstore` property in the metadata because that is generated solely by the CPI.

Rather than updating each CPI to know about the signed URL feature, we are instead removing the `blobstore` properties from the CPI. This will ensure that Director is the sole point of contact when configuring agent blobstore settings, and ensure that they are always properly redacted.