### PR TITLE
fix script not to depend on brew command

### DIFF
--- a/src/bosh_azure_cpi/bin/check-ruby-version
+++ b/src/bosh_azure_cpi/bin/check-ruby-version
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
-[[ ! -f $(brew --prefix)/share/chruby/chruby.sh ]] && {
+BREW_CMD=$(command -v brew)
+
+if [ -n "$BREW_CMD" ]; then
+  CHRUBY_PATH="$($BREW_CMD --prefix)/share/chruby/chruby.sh"
+else
+  CHRUBY_PATH=/usr/local/share/chruby/chruby.sh
+fi
+
+[[ ! -f "$CHRUBY_PATH" ]] && {
   echo "You need to install chruby. Please follow the README to install: https://github.com/postmodern/chruby#install"
   exit
 }
-source $(brew --prefix)/share/chruby/chruby.sh
+source "$CHRUBY_PATH"
 
 chruby $PROJECT_RUBY_VERSION
 if [[ "$?" -eq "1" ]]; then


### PR DESCRIPTION
Fixes #679

I've changed `check-ruby-version` script so that it executes on Windows WSL2 without errors when there is no `brew` installed. 
After the change local tests are working on Linux (WSL2).

# Checklist:

- [x] I have performed a self-review of my own code
- [x] All unit tests pass locally (after my changes)

