### PR TITLE
Prevent gcc version check for non xenial stemcells

### DIFF
--- a/src/bosh_azure_cpi/Gemfile
+++ b/src/bosh_azure_cpi/Gemfile
@@ -13,7 +13,10 @@ gem 'deep_merge',       '~> 1.2', '>= 1.2.1'
 gem 'net-smtp'
 
 #fast_jsonparser has a GCC requirement that cannot be guaranteed by all VMs the CPI might run on.
-gem 'fast_jsonparser', '~> 0.6.0', :install_if => `gcc -dumpversion`.to_i > 6
+if ((`uname`.include?('Linux')) && !(`lsb_release -sr`.include?('16.04'))) || `gcc -dumpversion`.to_i > 6
+  gem 'fast_jsonparser', '~> 0.6.0'
+end
+
 gem 'rspec-retry', group: :test
 
 group :development, :test do


### PR DESCRIPTION
# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] All unit tests pass locally (after my changes)

# Changelog

* The gcc version check for installing the fast_jsonparser gem is performed only on non-linux environments and linux environments other than xenial. This enables further hardening of bosh vms, which might involve getting rid of various packages and compilers like gcc from the stemcell.
