### PR TITLE
Allow specifying deployment VM's managed identity to optionally use

### DIFF
--- a/docs/advanced/managed-identity/README.md
+++ b/docs/advanced/managed-identity/README.md
@@ -75,6 +75,14 @@ Azure CPI `v35.5.0+` does **NOT** support the following features. You need to do
           default_security_group: nsg-azure
       ```
 
+    1. (Optional) Configure `managed_identity_resource_id` to the specific Azure resource ID of the managed identity you want to use. This can be done to prevent issues if the VM being used to create the BOSH director has more than one managed identity assigned to it.
+
+      ```
+      - type: replace
+        path: path: /cloud_provider/properties/azure?/managed_identity_resource_id?
+        value: /subscriptions/${subscription}>/resourcegroups/${resource-group}providers/Microsoft.ManagedIdentity/userAssignedIdentities/${managed-identity}
+      ```
+
 1. Configure managed identity in the resource pool of BOSH director VM. Please make sure the managed identity has been assigned a `Contributor` role. Please see [Assign a role to a user-assigned managed identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-portal#assign-a-role-to-a-user-assigned-managed-identity).
 
     ```
@@ -101,7 +109,7 @@ Azure CPI `v35.5.0+` does **NOT** support the following features. You need to do
         default_security_group: nsg-azure
     ```
 
-1. Deploy your BOSH director with `bosh creat-env`. Then CPI on the director VM can use the managed identity to request access tokens to create Azure resources.
+1. Deploy your BOSH director with `bosh create-env`. Then CPI on the director VM can use the managed identity to request access tokens to create Azure resources.
 
 ## Appendix: Azure Managed Identity
 

--- a/docs/advanced/managed-identity/README.md
+++ b/docs/advanced/managed-identity/README.md
@@ -75,12 +75,12 @@ Azure CPI `v35.5.0+` does **NOT** support the following features. You need to do
           default_security_group: nsg-azure
       ```
 
-    1. (Optional) Configure `managed_identity_resource_id` to the specific Azure resource ID of the managed identity you want to use. This can be done to prevent issues if the VM being used to create the BOSH director has more than one managed identity assigned to it.
+    1. (Optional) Configure `managed_identity_resource_id` to the specific Azure resource ID of the managed identity you want to use for calls made from your jumpbox VM. This can be set to prevent issues when the jumpbox VM being used to create the BOSH director has more than one managed identity assigned to it.
 
       ```
       - type: replace
-        path: path: /cloud_provider/properties/azure?/managed_identity_resource_id?
-        value: /subscriptions/${subscription}>/resourcegroups/${resource-group}providers/Microsoft.ManagedIdentity/userAssignedIdentities/${managed-identity}
+        path: /cloud_provider/properties/azure?/managed_identity_resource_id?
+        value: /subscriptions/<my-subscription>/resourcegroups/<my-resource-group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<my-identity-name>
       ```
 
 1. Configure managed identity in the resource pool of BOSH director VM. Please make sure the managed identity has been assigned a `Contributor` role. Please see [Assign a role to a user-assigned managed identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-portal#assign-a-role-to-a-user-assigned-managed-identity).

--- a/jobs/azure_cpi/spec
+++ b/jobs/azure_cpi/spec
@@ -44,6 +44,9 @@ properties:
   azure.default_managed_identity.user_assigned_identity_name:
     description: The user-assigned identity name associated with the VM. For the user-assigned identity specified here to be used, azure.credentials_source has to be set to `managed_identity`.
     default: null
+  azure.managed_identity_resource_id:
+    description: The specific resource ID of the managed identity to use for the azure cpi. This is required if the VM the cpi is being called from has multiple managed identities assigned to it.
+    default: null
   azure.ssh_user:
     description: Default ssh user for new vms
     default: vcap

--- a/jobs/azure_cpi/templates/cpi.json.erb
+++ b/jobs/azure_cpi/templates/cpi.json.erb
@@ -73,6 +73,10 @@
     end
   end
 
+  if_p('azure.managed_identity_resource_id') do |managed_identity_resource_id|
+    params['cloud']['properties']['azure']['managed_identity_resource_id'] = managed_identity_resource_id
+  end
+
   if_p('azure.storage_account_name') do |storage_account_name|
     params['cloud']['properties']['azure']['storage_account_name'] = storage_account_name
   end.else do

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
@@ -66,7 +66,7 @@ module Bosh::AzureCloud
 
     attr_reader :environment, :subscription_id, :location, :resource_group_name
     attr_reader :azure_stack
-    attr_reader :credentials_source, :tenant_id, :client_id, :client_secret, :default_managed_identity
+    attr_reader :credentials_source, :tenant_id, :client_id, :client_secret, :default_managed_identity, :managed_identity_resource_id
     attr_accessor :storage_account_name
     attr_reader :use_managed_disks
     attr_reader :default_security_group
@@ -91,6 +91,7 @@ module Bosh::AzureCloud
       @client_id = azure_config_hash['client_id']
       @client_secret = azure_config_hash['client_secret']
       @default_managed_identity = Bosh::AzureCloud::ManagedIdentity.new(azure_config_hash['default_managed_identity']) unless azure_config_hash['default_managed_identity'].nil?
+      @managed_identity_resource_id = azure_config_hash['managed_identity_resource_id']
 
       @use_managed_disks = azure_config_hash['use_managed_disks']
       @storage_account_name = azure_config_hash['storage_account_name']

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -2357,6 +2357,7 @@ module Bosh::AzureCloud
         'resource' => get_token_resource(@azure_config),
         'api-version' => api_version
       }
+      params['msi_res_id'] = @azure_config.managed_identity_resource_id unless @azure_config.managed_identity_resource_id.nil?
       uri.query = URI.encode_www_form(params)
       @logger.debug("authentication_endpoint: #{uri}")
 


### PR DESCRIPTION
# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero offenses (after my changes)

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
    ./bin/rubocop_check
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

Same as before adding in my changes:
```
1031 examples, 0 failures

Coverage report generated for RSpec to /root/workspace/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage. 4247 / 4279 LOC (99.25%) covered.
```

### Rubocop output:

Offenses, same as before adding in my changes:

```
Gemfile:15:11: W: [Correctable] Lint/ParenthesesAsGroupedExpression: (...) interpreted as grouped expression.
install_if (-> { (`uname`.include?('Linux') && !(`lsb_release -sr`.include?('16.04') if system('which lsb_release > /dev/null 2>&1'))) || `gcc -dumpversion`.to_i > 6 }) do
          ^
lib/cloud/azure/restapi/azure_client.rb:2725:7: C: [Correctable] Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
      if vm['identity'] && vm['identity']['type'] == 'UserAssigned'
      ^^
lib/cloud/azure/restapi/azure_client.rb:2726:98: C: [Correctable] Style/EachWithObject: Use each_with_object instead of inject.
        vm['identity']['userAssignedIdentities'] = vm['identity']['userAssignedIdentities'].keys.inject({}) { |result, k| result[k] = {}; result }
                                                                                                 ^^^^^^
lib/cloud/azure/restapi/azure_client.rb:2726:137: C: [Correctable] Style/Semicolon: Do not use semicolons to terminate expressions.
        vm['identity']['userAssignedIdentities'] = vm['identity']['userAssignedIdentities'].keys.inject({}) { |result, k| result[k] = {}; result }
                                                                                                                                        ^
lib/cloud/azure/vms/vm_manager.rb:21:5: C: Metrics/AbcSize: Assignment Branch Condition size for create is too high. [<87, 178, 53> 205.1/192]
    def create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_settings, network_spec, config) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloud/azure/vms/vm_manager.rb:21:5: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for create is too high. [45/39]
    def create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_settings, network_spec, config) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloud/azure/vms/vm_manager.rb:21:5: C: Metrics/MethodLength: Method has too many lines. [189/184]
    def create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_settings, network_spec, config) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloud/azure/vms/vm_manager.rb:21:5: C: Metrics/PerceivedComplexity: Perceived complexity for create is too high. [50/45]
    def create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_settings, network_spec, config) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/unit/blob_manager_spec.rb:608:62: C: [Correctable] Layout/SpaceAfterComma: Space missing after comma.
        .with(container_name, blob_name, { metadata: metadata,request_id: request_id })
                                                             ^
spec/unit/telemetry/telemetry_manager_spec.rb:87:20: C: [Correctable] Layout/HashAlignment: Align the keys of a hash literal if they span more than one line.
                   'subscription_id' => mock_azure_config.subscription_id,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/unit/telemetry/telemetry_manager_spec.rb:88:20: C: [Correctable] Layout/HashAlignment: Align the keys of a hash literal if they span more than one line.
                   'fake-key' => 'fake-value' })
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^

189 files inspected, 11 offenses detected, 7 offenses auto-correctable
```

# Changelog

* add `managed_identity_resource_id` option, resolves #670
