### PR TITLE
Native disk update

### DIFF
--- a/src/bosh_azure_cpi/Gemfile
+++ b/src/bosh_azure_cpi/Gemfile
@@ -12,7 +12,7 @@ gem 'jwt',              '~> 2.2', '>= 2.2.2'
 gem 'deep_merge',       '~> 1.2', '>= 1.2.1'
 gem 'net-smtp'
 # fast_jsonparser has a GCC requirement that cannot be guaranteed by all VMs the CPI might run on.
-install_if (-> { (`uname`.include?('Linux') && !(`lsb_release -sr`.include?('16.04') if system('which lsb_release > /dev/null 2>&1'))) || `gcc -dumpversion`.to_i > 6 }) do
+install_if(-> { (`uname`.include?('Linux') && !(`lsb_release -sr`.include?('16.04') if system('which lsb_release > /dev/null 2>&1'))) || `gcc -dumpversion`.to_i > 6 }) do
   gem 'fast_jsonparser', '~> 0.6.0'
 end
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/disk/disk_manager2.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/disk/disk_manager2.rb
@@ -45,6 +45,24 @@ module Bosh::AzureCloud
       @azure_client.create_empty_managed_disk(resource_group_name, disk_params)
     end
 
+    def update_disk(disk_id, size = nil, storage_account_type = nil, iops = nil, mbps = nil)
+      @logger.info("update_disk(#{disk_id}, #{size}, #{storage_account_type}, #{iops}, #{mbps})")
+      disk_params = {}
+      disk_params[:disk_size] = size if size
+      disk_params[:account_type] = storage_account_type if storage_account_type
+      disk_params[:iops] = iops if iops
+      disk_params[:mbps] = mbps if mbps
+
+      resource_group_name = disk_id.resource_group_name
+      unless disk_params.any?
+        @logger.info("No need to update disk '#{disk_id.disk_name}' in resource group '#{resource_group_name}'")
+        return
+      end
+
+      @logger.info("Start to update disk '#{disk_id.disk_name}' in resource group '#{resource_group_name}' with new parameters '#{disk_params}'")
+      @azure_client.update_managed_disk(resource_group_name, disk_id.disk_name, disk_params)
+    end
+
     def create_disk_from_blob(disk_id, blob_uri, location, storage_account_type, storage_account_id, zone = nil)
       @logger.info("create_disk_from_blob(#{disk_id}, #{blob_uri}, #{location}, #{storage_account_type}, #{storage_account_id}, #{zone})")
       resource_group_name = disk_id.resource_group_name

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -2767,7 +2767,9 @@ module Bosh::AzureCloud
     def remove_resources_from_vm(vm)
       vm.delete('resources')
       if vm['identity'] && vm['identity']['type'] == 'UserAssigned'
-        vm['identity']['userAssignedIdentities'] = vm['identity']['userAssignedIdentities'].keys.inject({}) { |result, k| result[k] = {}; result }
+        vm['identity']['userAssignedIdentities'] = vm['identity']['userAssignedIdentities'].keys.each_with_object({}) do |k, result|
+          result[k] = {}
+        end
       end
       vm
     end

--- a/src/bosh_azure_cpi/spec/integration/managed_disks_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/managed_disks_spec.rb
@@ -9,7 +9,7 @@ describe Bosh::AzureCloud::Cloud do
     described_class.new(cloud_options_managed, Bosh::AzureCloud::Cloud::CURRENT_API_VERSION)
   end
 
-  let(:size) { 10_000 }
+  let(:old_size) { 10_000 }
   let(:new_size) { 20_000 }
 
   before { @disk_id_pool = [] }
@@ -23,21 +23,97 @@ describe Bosh::AzureCloud::Cloud do
 
   context 'Resize a disk to a higher size' do
     it 'should work' do
-      @logger.info("Create new managed disk with #{size} MiB")
-      disk_cid = cpi_managed.create_disk(size, {})
+      @logger.info("Create new managed disk with #{old_size} MiB")
+      disk_cid = cpi_managed.create_disk(old_size, {})
       expect(disk_cid).not_to be_nil
       @disk_id_pool.push(disk_cid)
 
       @logger.info("Resize managed disk '#{disk_cid}' to #{new_size} MiB")
       cpi_managed.resize_disk(disk_cid, new_size)
 
-      disk_id_obj = Bosh::AzureCloud::DiskId.parse(disk_cid, @azure_config.resource_group_name)
-      disk = get_azure_client.get_managed_disk_by_name(@default_resource_group_name, disk_id_obj.disk_name)
+      disk = get_disk(disk_cid)
       expect(disk[:disk_size]).to eq(cpi_managed.mib_to_gib(new_size))
 
       @logger.info("Delete managed disk '#{disk_cid}'")
       cpi_managed.delete_disk(disk_cid)
       @disk_id_pool.delete(disk_cid)
     end
+  end
+
+  describe '#update_disk' do
+    context 'When disk properties change on a storage type that does support changing it' do
+      let(:old_storage_account_type) { 'Premium_LRS' }
+      let(:new_storage_account_type) { 'PremiumV2_LRS' }
+      let(:new_iops) { 3500 } # The default value of iops is 3000 for PremiumV2_LRS
+      let(:new_mbps) { 125 } # The default value of mbps is 120 for PremiumV2_LRS
+
+      it 'should update the disk properties accordingly' do
+        @logger.info("Create a managed disk with #{old_size} MiB")
+        disk_cid = cpi_managed.create_disk(old_size, { 'storage_account_type' => old_storage_account_type })
+        @disk_id_pool.push(disk_cid) if disk_cid
+
+        @logger.info("Check the disk properties of the created disk '#{disk_cid}'")
+        disk = get_disk(disk_cid)
+        expect(disk[:disk_size]).not_to eq(cpi_managed.mib_to_gib(new_size))
+        expect(disk[:iops]).not_to eq(new_iops)
+        expect(disk[:mbps]).not_to eq(new_mbps)
+        expect(disk[:sku_name]).to eq(old_storage_account_type)
+
+        @logger.info("Update managed disk '#{disk_cid}' to #{new_size} MiB, iops: #{new_iops}, mbps: #{new_mbps}, storage_account_type: #{new_storage_account_type}")
+        cloud_properties = { 'iops' => new_iops, 'mbps' => new_mbps, 'storage_account_type' => new_storage_account_type }
+        cpi_managed.update_disk(disk_cid, new_size, cloud_properties)
+
+        @logger.info("Check the disk properties of the updated disk '#{disk_cid}'")
+        disk = get_disk(disk_cid)
+        expect(disk[:disk_size]).to eq(cpi_managed.mib_to_gib(new_size))
+        expect(disk[:iops]).to eq(new_iops)
+        expect(disk[:mbps]).to eq(new_mbps)
+        expect(disk[:sku_name]).to eq(new_storage_account_type)
+
+        @logger.info("Delete managed disk '#{disk_cid}'")
+        cpi_managed.delete_disk(disk_cid)
+        @disk_id_pool.delete(disk_cid)
+      end
+    end
+
+    context 'When disk properties change on a storage type that does not support changing it' do
+      let(:old_storage_account_type) { 'Standard_LRS' }
+      let(:new_storage_account_type) { 'Premium_LRS' }
+      let(:new_iops) { 1000 }
+      let(:new_mbps) { 120 }
+
+      it 'raises no error and sets the disk type specific default' do
+        @logger.info("Create a managed disk with #{old_size} MiB")
+        disk_cid = cpi_managed.create_disk(old_size, { 'storage_account_type' => old_storage_account_type })
+        @disk_id_pool.push(disk_cid) if disk_cid
+
+        @logger.info("Check the disk properties of the managed disk '#{disk_cid}'")
+        disk = get_disk(disk_cid)
+        expect(disk[:sku_name]).to eq(old_storage_account_type)
+        expect(disk[:iops]).to eq(500) # iops equals the default value of iops for Standard_LRS
+        expect(disk[:mbps]).to eq(60) # mbps equals the default value of mbps for Standard_LRS
+
+        @logger.info("Try to update managed disk '#{disk_cid}' to iops: #{new_iops}, mbps: #{new_mbps}")
+        cloud_properties = { 'iops' => new_iops, 'mbps' => new_mbps, 'storage_account_type' => new_storage_account_type }
+        expect do
+          cpi_managed.update_disk(disk_cid, old_size, cloud_properties)
+        end.not_to raise_error
+
+        @logger.info("Check the disk properties of the updated disk '#{disk_cid}'")
+        disk = get_disk(disk_cid)
+        expect(disk[:sku_name]).to eq(new_storage_account_type)
+        expect(disk[:iops]).to eq(120) # iops equals the default value of iops for Premium_LRS
+        expect(disk[:mbps]).to eq(25) # mbps equals the default value of mbps for Premium_LRS
+
+        @logger.info("Delete managed disk '#{disk_cid}'")
+        cpi_managed.delete_disk(disk_cid)
+        @disk_id_pool.delete(disk_cid)
+      end
+    end
+  end
+
+  def get_disk(disk_cid)
+    disk_id_obj = Bosh::AzureCloud::DiskId.parse(disk_cid, @azure_config.resource_group_name)
+    get_azure_client.get_managed_disk_by_name(@default_resource_group_name, disk_id_obj.disk_name)
   end
 end

--- a/src/bosh_azure_cpi/spec/unit/azure_client/managed_disks_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/managed_disks_spec.rb
@@ -414,7 +414,9 @@ describe Bosh::AzureCloud::AzureClient do
         zones: ['fake-zone'],
         properties: {
           provisioningState: 'd',
-          diskSizeGB: 'e'
+          diskSizeGB: 'e',
+          diskMBpsReadWrite: 11,
+          diskIOPSReadWrite: 22
         }
       }
     end
@@ -430,7 +432,9 @@ describe Bosh::AzureCloud::AzureClient do
         sku_tier: 'g',
         zone: 'fake-zone',
         provisioning_state: 'd',
-        disk_size: 'e'
+        disk_size: 'e',
+        mbps: 11,
+        iops: 22
       }
     end
 

--- a/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/blob_manager_spec.rb
@@ -605,7 +605,7 @@ describe Bosh::AzureCloud::BlobManager do
       metadata = {}
 
       expect(blob_service).to receive(:create_blob_snapshot)
-        .with(container_name, blob_name, { metadata: metadata,request_id: request_id })
+        .with(container_name, blob_name, { metadata: metadata, request_id: request_id })
         .and_return(snapshot_time)
 
       expect(

--- a/src/bosh_azure_cpi/spec/unit/cloud/update_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/update_disk_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'unit/cloud/shared_stuff'
+
+describe Bosh::AzureCloud::Cloud do
+  include_context 'shared stuff'
+
+  describe '#update_disk' do
+    let(:disk_cid) { 'e55144a3-0c06-4240-8f15-9a7bc7b35d1f' }
+    let(:disk_name) { 'fake-disk-name' }
+    let(:disk_id_object) { instance_double(Bosh::AzureCloud::DiskId) }
+    let(:default_resource_group_name) { MOCK_RESOURCE_GROUP_NAME }
+    let(:resource_group_name) { 'fake-resource-group-name' }
+
+    let(:iops) { 500 }
+    let(:mbps) { 100 }
+    let(:storage_account) { 'fake-storage-account' }
+    let(:cloud_properties) { { 'storage_account_type' => storage_account, 'iops' => iops, 'mbps' => mbps } }
+
+    let(:old_disk_size_in_gib) { 512 }
+    let(:new_disk_size_in_gib) { 1024 }
+    let(:new_disk_size) { new_disk_size_in_gib * 1024 }
+
+    before do
+      allow(Bosh::AzureCloud::DiskId).to receive(:parse)
+        .and_return(disk_id_object)
+      allow(disk_id_object).to receive(:resource_group_name)
+        .and_return(resource_group_name)
+      allow(disk_id_object).to receive(:disk_name)
+        .and_return(disk_name)
+      allow(disk_id_object).to receive(:caching)
+        .and_return('None')
+      allow(disk_manager2).to receive(:get_data_disk)
+        .and_return({ disk_size: old_disk_size_in_gib }) # in GiB
+      allow(disk_manager2).to receive(:update_disk)
+
+      allow(telemetry_manager).to receive(:monitor)
+        .with('update_disk', { id: disk_cid })
+        .and_call_original
+      allow(Bosh::Clouds::Config.logger).to receive(:info)
+    end
+
+    it 'updates the disk with the new size and cloud properties' do
+      expect(disk_manager2).to receive(:update_disk)
+        .with(disk_id_object, new_disk_size_in_gib, storage_account, iops, mbps)
+      expect(Bosh::Clouds::Config.logger).to receive(:info)
+        .with(/Finished update of disk 'fake-disk-name'/)
+
+      expect do
+        managed_cloud.update_disk(disk_cid, new_disk_size, cloud_properties)
+      end.not_to raise_error
+    end
+
+    it 'raises an error if the disk is not found' do
+      allow(disk_manager2).to receive(:get_data_disk).and_return(nil)
+
+      expect do
+        managed_cloud.update_disk(disk_cid, new_disk_size, cloud_properties)
+      end.to raise_error(/Disk 'fake-disk-name' not found/)
+    end
+
+    context 'when the disk size are the same and cloud properties change' do
+      let(:new_disk_size_in_gib) { old_disk_size_in_gib }
+
+      it 'does not try to update the property' do
+        expect(disk_manager2).to receive(:update_disk)
+
+        expect do
+          managed_cloud.update_disk(disk_cid, new_disk_size, cloud_properties)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when the disk size are the same and cloud properties do not change' do
+      let(:new_disk_size_in_gib) { old_disk_size_in_gib }
+      let(:cloud_properties) { {} }
+
+      it 'does not try to update the property' do
+        expect(disk_manager2).not_to receive(:update_disk)
+
+        expect do
+          managed_cloud.update_disk(disk_cid, new_disk_size, cloud_properties)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when the disk size is smaller' do
+      let(:new_disk_size_in_gib) { 256 }
+
+      it 'raises an error' do
+        expect do
+          managed_cloud.update_disk(disk_cid, new_disk_size, cloud_properties)
+        end.to raise_error(/Disk size cannot be decreased/)
+      end
+    end
+
+    context 'when caching settings changes' do
+      let(:old_caching) { 'None' }
+      let(:new_caching) { 'ReadWrite' }
+      let(:cloud_properties) { { 'caching' => new_caching } }
+
+      it 'raises an error' do
+        allow(disk_manager2).to receive(:get_data_disk).and_return({ disk_size: old_disk_size_in_gib, caching: old_caching })
+
+        expect do
+          managed_cloud.update_disk(disk_cid, new_disk_size, cloud_properties)
+        end.to raise_error(/Disk caching cannot be modified/)
+      end
+    end
+  end
+end

--- a/src/bosh_azure_cpi/spec/unit/disk_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/disk_manager2_spec.rb
@@ -59,6 +59,29 @@ describe Bosh::AzureCloud::DiskManager2 do
     end
   end
 
+  describe '#update_disk' do
+    let(:disk_name) { 'fake-disk-name' }
+    let(:resource_group_name) { 'fake-resource-group-name' }
+
+    before do
+      allow(azure_client).to receive(:update_managed_disk).with(anything, anything, anything).and_return(nil)
+    end
+
+    it 'updates the disk' do
+      expected = {
+        disk_size: 4,
+        account_type: 'Premium_LRS',
+        iops: 100,
+        mbps: 20
+      }
+      expect(azure_client).to receive(:update_managed_disk).with(resource_group_name, disk_name, expected)
+
+      expect do
+        disk_manager2.update_disk(disk_id, 4, 'Premium_LRS', 100, 20)
+      end.not_to raise_error
+    end
+  end
+
   describe '#create_disk_from_blob' do
     let(:blob_data_disk_prefix) { 'bosh-data' }
     let(:blob_uri) { 'fake-blob-uri' }

--- a/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/telemetry/telemetry_manager_spec.rb
@@ -84,8 +84,8 @@ describe Bosh::AzureCloud::TelemetryManager do
         it 'should return the result but do not report the event' do
           expect(event_param_message).to receive(:value=)
             .with({ 'msg' => 'Successed',
-                   'subscription_id' => mock_azure_config.subscription_id,
-                   'fake-key' => 'fake-value' })
+                    'subscription_id' => mock_azure_config.subscription_id,
+                    'fake-key' => 'fake-value' })
           expect(telemetry_manager).not_to receive(:_report_event)
 
           expect(


### PR DESCRIPTION
# Summary

This change introduces a new cloud method called `update_disk`, which can be used to update disk parameters on an existing Azure Disk. Disk size and storage account type can be changed on any data disk. For storage account types PremiumV2_LRS and Ultra Disks, iops and throughput (mbps) can also be changed.

Relates to: https://github.com/cloudfoundry/bosh/issues/2496

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [ ] Rubocop reports zero offenses (after my changes) -- there is a complexity violation in the disk manager. either we disable the check for the method or we can discuss if you prefer a different solution.

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
    ./bin/rubocop_check
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

```
Finished in 6.62 seconds (files took 0.73321 seconds to load)
1044 examples, 0 failures
```

### Integration Test output:

```sh
$ bundle exec rspec ./spec/integration
...
Finished in 1 minute 17.39 seconds (files took 0.43431 seconds to load)
3 examples, 0 failures
```

### Rubocop output:

```
Inspecting 190 files
.......C........................................C.............................................................................................................................................

Offenses:

lib/cloud/azure/disk/disk_manager2.rb:48:5: C: Metrics/ParameterLists: Method has too many optional parameters. [4/3]
    def update_disk(disk_id, size = nil, storage_account_type = nil, iops = nil, mbps = nil) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloud/azure/vms/vm_manager.rb:21:5: C: Metrics/AbcSize: Assignment Branch Condition size for create is too high. [<87, 178, 53> 205.1/192]
    def create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_settings, network_spec, config) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloud/azure/vms/vm_manager.rb:21:5: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for create is too high. [45/39]
    def create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_settings, network_spec, config) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloud/azure/vms/vm_manager.rb:21:5: C: Metrics/MethodLength: Method has too many lines. [189/184]
    def create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_settings, network_spec, config) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/cloud/azure/vms/vm_manager.rb:21:5: C: Metrics/PerceivedComplexity: Perceived complexity for create is too high. [50/45]
    def create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_settings, network_spec, config) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

190 files inspected, 5 offenses detected
```

# Changelog

* The `update_disk` cloud method has been introduced, allowing updates to disk parameters for Azure Disks, including disk size and storage account type. For PremiumV2_LRS and Ultra Disks, IOPS and throughput (mbps) adjustments are now possible.
