### PR TITLE
Add Dev Container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,66 @@
+FROM ruby:3.2.5
+
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV GEM_HOME=~/.gems
+ENV BOSH_CLI_VERSION="7.6.3"
+ENV CHRUBY_VERSION="0.3.9"
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        build-essential \
+        ca-certificates \
+        curl \
+        direnv \
+        gcc \
+        gettext-base \
+        git \
+        gnupg \
+        jq \
+        libreadline-dev \
+        libssl-dev \
+        libxslt1-dev \
+        libxml2-dev \
+        libyaml-dev \
+        libsqlite3-dev \
+        lsb-release \
+        make \
+        openssl \
+        python3-pip \
+        sqlite3 \
+        sudo \
+        wget \
+        zlib1g-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_VERSION}/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64 -O /usr/local/bin/bosh && \
+    chmod +x /usr/local/bin/bosh
+
+RUN wget -O chruby.tar.gz https://github.com/postmodern/chruby/archive/v${CHRUBY_VERSION}.tar.gz && \
+    tar -xzvf chruby.tar.gz && \
+    cd chruby-*/ && \
+    make install && \
+    cd .. && \
+    rm -rf ./chruby-* && \
+    chmod +x /usr/local/share/chruby/chruby.sh && \
+    echo 'source /usr/local/share/chruby/chruby.sh' >> ~/.profile
+
+RUN echo 'gem: --no-document' > /etc/gemrc && \
+    gem update --system && \
+    bundle config --global path "${GEM_HOME}" && \
+    bundle config --global bin "${GEM_HOME}/bin" && \
+    gem install bundler && \
+    gem install rubocop && \
+    gem install ruby-debug-ide
+
+COPY --from=golang:latest /usr/local/go /usr/local/go
+ENV GOROOT=/usr/local/go PATH=/usr/local/go/bin:$PATH
+
+RUN echo 'eval "$(direnv hook bash)"' >> ~/.profile
+
+RUN useradd -ms /bin/bash vscode \
+    && echo vscode ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/vscode \
+    && chmod 0440 /etc/sudoers.d/vscode
+
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rebornix.ruby",
+				"wingrunr21.vscode-ruby"
+			]
+		}
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/azure-cli:1": {
+			"version": "latest"
+		}
+    },
+	"remoteUser": "vscode",
+	"postAttachCommand": [".devcontainer/install.sh"]
+}

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+direnv allow
+
+(
+  cd src/bosh_azure_cpi
+
+  bundle config set --local path vendor/package
+  bundle config set --local with "development:test"
+  bundle install
+)

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,6 +4,12 @@
 
 ## Prepare the development environment
 
+### Dev Container
+
+You can [start a dev container](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/cloudfoundry/bosh-azure-cpi-release), which contains all necessary tools to develop the Azure CPI. Learn more about [dev containers](https://containers.dev/).
+
+### Manual Setup
+
 1. Install dependencies
 
     ```bash


### PR DESCRIPTION
# Summary

DevContainers are a feature in Visual Studio Code that allow you to define a containerized development environment. This ensures consistency across different development setups and makes it easier to onboard new developers by providing a pre-configured environment.

This change introduces a Dockerfile for a Ruby 3.2.5 development environment using DevContainers, incorporating essential dependencies like BOSH CLI, chruby, Azure CLI and build tools. It adds a 'vscode' user with sudo rights for development, and installs Ruby gems such as bundler, rubocop, and ruby-debug-ide. Additionally, it configures direnv and chruby for environment management.

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero offenses (after my changes)

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    ./bin/test-unit
    ./bin/rubocop_check
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

> (TODO: Paste unit test script summary output here)

### Rubocop output:

no source code touched.

# Changelog

* Added Support for Dev Containers

# Peers

@HappyTobi 