### PR TITLE
ensure that cpi uses the correct gem path during runtime

### DIFF
--- a/jobs/azure_cpi/templates/cpi.erb
+++ b/jobs/azure_cpi/templates/cpi.erb
@@ -4,6 +4,7 @@ set -e
 
 BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
 source ${BOSH_PACKAGES_DIR}/azure-cpi-ruby-3.3/bosh/runtime.env
+ruby_major_minor=$(ruby -v | grep -E -o "[0-9]+\.[0-9]")
 BOSH_JOBS_DIR=${BOSH_JOBS_DIR:-/var/vcap/jobs}
 export HOME=~
 
@@ -23,6 +24,7 @@ export no_proxy="<%= no_proxy %>"
 <% end %>
 
 export BUNDLE_GEMFILE="$BOSH_PACKAGES_DIR/bosh_azure_cpi/Gemfile"
+export GEM_HOME="${BOSH_PACKAGES_DIR}/bosh_aws_cpi/gem_home/ruby/${ruby_major_minor}.0"
 
 exec bundle exec \
     "$BOSH_PACKAGES_DIR/bosh_azure_cpi/bin/azure_cpi" \


### PR DESCRIPTION
when executing create-env on a nix based oci image gems cannot be found.

Error message: "Cannot find [gems] in locally installed gems"

This PR fixes it.

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] All unit tests pass locally (after my changes)
- [ ] Rubocop reports zero errors (after my changes)

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rake spec:unit
    bundle exec rake rubocop
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

Finished in 4.85 seconds (files took 3.43 seconds to load)
1034 examples, 0 failures


### Rubocop output:

Lots of Rubocop issues in files that are not affected by this PR:

191 files inspected, 50 offenses detected, 28 offenses autocorrectable

# Changelog

* 
* 
* 
