### PR TITLE
Add error handling for unsupported disk conversion

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -958,11 +958,10 @@ module Bosh::AzureCloud
       request_body['properties']['diskIOPSReadWrite'] = params[:iops] if params[:iops]
       request_body['properties']['diskMBpsReadWrite'] = params[:mbps] if params[:mbps]
       request_body.delete('properties') if request_body['properties'].empty?
+      return unless request_body.any?
 
-      if request_body.any?
-        url = rest_api_url(REST_API_PROVIDER_COMPUTE, REST_API_DISKS, resource_group_name: resource_group_name, name: name)
-        http_patch(url, request_body)
-      end
+      url = rest_api_url(REST_API_PROVIDER_COMPUTE, REST_API_DISKS, resource_group_name: resource_group_name, name: name)
+      http_patch(url, request_body)
     end
 
     def resize_managed_disk(resource_group_name, params)


### PR DESCRIPTION
# Summary

Certain Azure storage account types, such as `PremiumV2`, can't be converted automatically, as detailed in issue #699. Attempting to change the storage type would result in an error from the Azure API, e.g.:

```json
{
  "error": {
    "code": "OperationNotAllowed",
    "message": "Changing a disk's account type from 'PremiumV2_LRS' to 'Premium_LRS' is not supported."
  }
}
```

Currently, bosh does not specifically handles this error, but interprets it as a general Azure error, which causes a deployment failure when attempting to switch to a storage type that is incompatible with conversion in the manifest.

<details>
<summary>Example</summary>

```
Task 22 | 15:52:07 | Updating instance zookeeper: zookeeper/54cdcdc2-8494-4ad3-9283-034a5047766b (0) (canary)
Task 22 | 15:52:08 | L executing pre-stop: zookeeper/54cdcdc2-8494-4ad3-9283-034a5047766b (0) (canary)
Task 22 | 15:52:08 | L executing drain: zookeeper/54cdcdc2-8494-4ad3-9283-034a5047766b (0) (canary)
Task 22 | 15:52:09 | L stopping jobs: zookeeper/54cdcdc2-8494-4ad3-9283-034a5047766b (0) (canary)
Task 22 | 15:52:11 | L executing post-stop: zookeeper/54cdcdc2-8494-4ad3-9283-034a5047766b (0) (canary) (00:00:31)
                   L Error: Unknown CPI error 'Bosh::AzureCloud::AzureError' with message 'http_patch - http code: 400
x-ms-client-request-id: 18dffbfb-6d70-482a-b3aa-9bbb98bcc9a1
x-ms-request-id: 54356faf-4aa6-4441-895c-716af9b122vf
x-ms-correlation-request-id: 5fcdc82d-c27f-4f66-accb-4b151aab4dxq
x-ms-routing-request-id: EASTUS2:20241122T155238Z:5fcdc82d-c27f-4f66-accb-4b151aab4fb
Error message: {
  "error": {
    "code": "OperationNotAllowed",
    "message": "Changing a disk's account type from 'PremiumV2_LRS' to 'Premium_LRS' is not supported."
  }
}' in 'update_disk' CPI method (CPI request ID: 'cpi-303168')
```

</details>

In response to such errors from the Azure API, we now raise a `NotSupported` exception. This instructs bosh to follow the standard disk update process, which involves creating a new disk, attaching both the new and the old disks to the VM, copying the data to the new disk, and then detaching the old disk.

This approach prevents issues for users who might have accidentally chosen such a disk type and wish to revert, avoiding a scenario where the deployment fails and cannot be fixed in any other way.

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero errors (after my changes)

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rake spec:unit
    bundle exec rake rubocop
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

Unit tests

```
Finished in 4.8 seconds (files took 5.17 seconds to load)
1034 examples, 0 failures

Coverage report generated for RSpec to /workspaces/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage.
Line Coverage: 49.5% (19089 / 38564)
/workspaces/bosh-azure-cpi-release/src/bosh_azure_cpi
```

### Rubocop output:

There are 52 offenses. None of them were introduced by the code changes of this PR.

# Changelog

* Handle unsupported disk conversion operations by defaulting to the default copy mechanism.
