### PR TITLE
Do not try to create availability set with more fault domains than the region supports when migrating from unmanaged to managed disks

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -2039,6 +2039,18 @@ module Bosh::AzureCloud
       http_patch(url, request_body)
     end
 
+    def get_max_fault_domains_for_location(location)
+      error_text = "Unable to get maximum fault domains for location '#{location}'"
+      url =  "/subscriptions/#{uri_escape(@azure_config.subscription_id)}"
+      url += "/providers/#{REST_API_PROVIDER_COMPUTE}"
+      url += "/skus"
+      skus = get_resource_by_id(url, "$filter" => "location eq '#{location}'")['value']
+      raise error_text unless skus
+      sku_for_location = skus.find { |sku| sku['name'] == 'Aligned' && sku['locations'].map(&:downcase).include?(location.downcase) }
+      raise error_text unless sku_for_location
+      sku_for_location['capabilities'].find { |capability| capability['name'] == 'MaximumPlatformFaultDomainCount' }['value'].to_i
+    end
+
     private
 
     # @return [Hash]

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_availability_set.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_availability_set.rb
@@ -45,9 +45,10 @@ module Bosh::AzureCloud
           cloud_error("availability set '#{availability_set_name}' already exists. It's not allowed to update it from managed to unmanaged.")
         elsif @use_managed_disks && !availability_set[:managed]
           @logger.info("availability set '#{availability_set_name}' exists, but it needs to be updated from unmanaged to managed.")
+          maximum_fault_domain_count = [availability_set[:platform_fault_domain_count], @azure_client.get_max_fault_domains_for_location(location)].compact.min
           availability_set_params.merge!(
             platform_update_domain_count: availability_set[:platform_update_domain_count],
-            platform_fault_domain_count: availability_set[:platform_fault_domain_count],
+            platform_fault_domain_count: maximum_fault_domain_count,
             managed: true
           )
           @azure_client.create_availability_set(resource_group_name, availability_set_params)

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/availability_set_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/availability_set_spec.rb
@@ -67,6 +67,7 @@ describe Bosh::AzureCloud::VMManager do
               .with(MOCK_RESOURCE_GROUP_NAME, vm_props.availability_set.name)
               .and_return(availability_set)
             allow(azure_client).to receive(:create_availability_set)
+            allow(azure_client).to receive(:get_max_fault_domains_for_location).with(location).and_return(3)
           end
 
           let(:instance_types) { %w[Standard_DS2_v3 Standard_D2_v3] }
@@ -931,13 +932,14 @@ describe Bosh::AzureCloud::VMManager do
                 managed: true
               }
             end
+            let(:location_fault_domain_count) { 2 }
             let(:avset_params) do
               {
                 name: existing_avset[:name],
                 location: existing_avset[:location],
                 tags: existing_avset[:tags],
                 platform_update_domain_count: existing_avset[:platform_update_domain_count],
-                platform_fault_domain_count: existing_avset[:platform_fault_domain_count],
+                platform_fault_domain_count: location_fault_domain_count,
                 managed: true
               }
             end
@@ -947,6 +949,8 @@ describe Bosh::AzureCloud::VMManager do
                 allow(azure_client).to receive(:get_availability_set_by_name)
                   .with(MOCK_RESOURCE_GROUP_NAME, vm_props.availability_set.name)
                   .and_return(existing_avset)
+
+                allow(azure_client).to receive(:get_max_fault_domains_for_location).with(location).and_return(location_fault_domain_count)
               end
 
               it 'should update the managed property of the availability set' do


### PR DESCRIPTION
Part of the migration is update the availability set and just using the existing fault domains on the old set. In unmanaged availability sets, it's possible to have more fault domains than the region supports but this is not supported for managed availability sets so it throws an error.

Now we use the lesser of the region maximum and the previous setting. This does involve fetching the maximum from the region for each set migration, which is a large API payload from Azure, but once a deployment has been migrated it won't need to make these calls again.

