### PR TITLE
Add support for customer provided encryption keys for disks.

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -358,9 +358,10 @@ module Bosh::AzureCloud
             caching = cloud_properties.fetch('caching', 'None')
             iops = cloud_properties.fetch('iops', nil)
             mbps = cloud_properties.fetch('mbps', nil)
+            disk_encryption_set_name = cloud_properties.fetch('disk_encryption_set_name', nil)
             validate_disk_caching(caching)
             disk_id = DiskId.create(caching, true, resource_group_name: resource_group_name)
-            @disk_manager2.create_disk(disk_id, location, size / 1024, storage_account_type, zone, iops, mbps)
+            @disk_manager2.create_disk(disk_id, location, size / 1024, storage_account_type, zone, iops, mbps, disk_encryption_set_name: disk_encryption_set_name)
           else
             storage_account_name = _azure_config.storage_account_name
             caching = cloud_properties.fetch('caching', 'None')

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/ephemeral_disk.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/ephemeral_disk.rb
@@ -2,15 +2,16 @@
 
 module Bosh::AzureCloud
   class EphemeralDisk
-    attr_reader :use_root_disk, :size, :type, :caching, :iops, :mbps
+    attr_reader :use_root_disk, :size, :type, :caching, :iops, :mbps, :disk_encryption_set_name
 
-    def initialize(use_root_disk, size, type, caching, iops, mbps)
+    def initialize(use_root_disk, size, type, caching, iops, mbps, disk_encryption_set_name: nil)
       @use_root_disk = use_root_disk
       @size = size
       @type = type
       @caching = caching
       @iops = iops
       @mbps = mbps
+      @disk_encryption_set_name = disk_encryption_set_name
     end
   end
 end

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/root_disk.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/root_disk.rb
@@ -2,12 +2,13 @@
 
 module Bosh::AzureCloud
   class RootDisk
-    attr_reader :size, :type, :placement
+    attr_reader :size, :type, :placement, :disk_encryption_set_name
 
-    def initialize(size, type, placement)
+    def initialize(size, type, placement, disk_encryption_set_name: nil)
       @size = size
       @type = type
       @placement = placement
+      @disk_encryption_set_name = disk_encryption_set_name
     end
   end
 end

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
@@ -44,7 +44,8 @@ module Bosh::AzureCloud
       @root_disk = Bosh::AzureCloud::RootDisk.new(
         root_disk_hash['size'],
         root_disk_hash['type'],
-        _default_root_disk_placement(root_disk_hash['placement'])
+        _default_root_disk_placement(root_disk_hash['placement']),
+        disk_encryption_set_name: root_disk_hash['disk_encryption_set_name']
       )
 
       cloud_error("Only one of 'type' and 'placement' is allowed to be configured for the root_disk when 'placement' is not set to persistent") if @root_disk.placement != 'remote' && !@root_disk.type.nil? && !global_azure_config.use_managed_disks
@@ -56,7 +57,8 @@ module Bosh::AzureCloud
         ephemeral_disk_hash['type'],
         ephemeral_disk_hash['caching'],
         ephemeral_disk_hash['iops'],
-        ephemeral_disk_hash['mbps']
+        ephemeral_disk_hash['mbps'],
+        disk_encryption_set_name: ephemeral_disk_hash['disk_encryption_set_name']
       )
 
       @caching = vm_properties.fetch('caching', 'ReadWrite')

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_disk.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_disk.rb
@@ -8,14 +8,14 @@ module Bosh::AzureCloud
       if @use_managed_disks
         ephemeral_disk = @disk_manager2.ephemeral_disk(instance_id.vm_name, vm_props.instance_type, vm_props.ephemeral_disk.size,
                                                        vm_props.ephemeral_disk.type, vm_props.ephemeral_disk.use_root_disk, vm_props.ephemeral_disk.caching,
-                                                       vm_props.ephemeral_disk.iops, vm_props.ephemeral_disk.mbps)
+                                                       vm_props.ephemeral_disk.iops, vm_props.ephemeral_disk.mbps, disk_encryption_set_name: vm_props.ephemeral_disk.disk_encryption_set_name)
 
         # check if disk has the default behavior
         if vm_props.root_disk.placement == 'remote'
-          os_disk = @disk_manager2.os_disk(instance_id.vm_name, stemcell_info, vm_props.root_disk.size, vm_props.caching, vm_props.ephemeral_disk.use_root_disk)
+          os_disk = @disk_manager2.os_disk(instance_id.vm_name, stemcell_info, vm_props.root_disk.size, vm_props.caching, vm_props.ephemeral_disk.use_root_disk, disk_encryption_set_name: vm_props.root_disk.disk_encryption_set_name)
         else
           ephemeral_os_disk = @disk_manager2.ephemeral_os_disk(instance_id.vm_name, stemcell_info, vm_props.root_disk.size, vm_props.ephemeral_disk.size,
-                                                               vm_props.ephemeral_disk.use_root_disk, vm_props.root_disk.placement)
+                                                               vm_props.ephemeral_disk.use_root_disk, vm_props.root_disk.placement, disk_encryption_set_name: vm_props.root_disk.disk_encryption_set_name)
         end
       else
         storage_account_name = instance_id.storage_account_name

--- a/src/bosh_azure_cpi/spec/unit/cloud/create_disk_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/cloud/create_disk_spec.rb
@@ -100,7 +100,7 @@ describe Bosh::AzureCloud::Cloud do
             .with(caching, true, { resource_group_name: default_resource_group_name })
             .and_return(disk_id_object)
           expect(disk_manager2).to receive(:create_disk)
-            .with(disk_id_object, rg_location, disk_size_in_gib, 'Standard_LRS', zone, iops, mbps)
+            .with(disk_id_object, rg_location, disk_size_in_gib, 'Standard_LRS', zone, iops, mbps, disk_encryption_set_name: nil)
           expect(telemetry_manager).to receive(:monitor)
             .with('create_disk', { id: '', extras: { 'disk_size' => disk_size } })
             .and_call_original
@@ -152,11 +152,9 @@ describe Bosh::AzureCloud::Cloud do
                 .with(caching, true, { resource_group_name: resource_group_name })
                 .and_return(disk_id_object)
               expect(disk_manager2).to receive(:create_disk)
-                .with(disk_id_object, vm_location, disk_size_in_gib, 'Premium_LRS', vm_zone, iops, mbps)
+                .with(disk_id_object, vm_location, disk_size_in_gib, 'Premium_LRS', vm_zone, iops, mbps, disk_encryption_set_name: nil)
 
-              expect do
-                managed_cloud.create_disk(disk_size, cloud_properties, vm_cid)
-              end.not_to raise_error
+              managed_cloud.create_disk(disk_size, cloud_properties, vm_cid)
             end
           end
 
@@ -173,7 +171,7 @@ describe Bosh::AzureCloud::Cloud do
                 .with(caching, true, { resource_group_name: resource_group_name })
                 .and_return(disk_id_object)
               expect(disk_manager2).to receive(:create_disk)
-                .with(disk_id_object, vm_location, disk_size_in_gib, 'Standard_LRS', vm_zone, iops, mbps)
+                .with(disk_id_object, vm_location, disk_size_in_gib, 'Standard_LRS', vm_zone, iops, mbps, disk_encryption_set_name: nil)
 
               expect do
                 managed_cloud.create_disk(disk_size, cloud_properties, vm_cid)
@@ -198,7 +196,7 @@ describe Bosh::AzureCloud::Cloud do
                 .with(caching, true, { resource_group_name: resource_group_name })
                 .and_return(disk_id_object)
               expect(disk_manager2).to receive(:create_disk)
-                .with(disk_id_object, vm_location, disk_size_in_gib, 'PremiumV2_LRS', vm_zone, iops, mbps)
+                .with(disk_id_object, vm_location, disk_size_in_gib, 'PremiumV2_LRS', vm_zone, iops, mbps, disk_encryption_set_name: nil)
 
               expect do
                 managed_cloud.create_disk(disk_size, cloud_properties, vm_cid)

--- a/src/bosh_azure_cpi/spec/unit/disk_manager2_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/disk_manager2_spec.rb
@@ -46,7 +46,8 @@ describe Bosh::AzureCloud::DiskManager2 do
         },
         disk_size: size,
         account_type: storage_account_type,
-        zone: zone
+        zone: zone,
+        disk_encryption_set_name: 'set_name'
       }
     end
 
@@ -54,7 +55,7 @@ describe Bosh::AzureCloud::DiskManager2 do
       expect(azure_client).to receive(:create_empty_managed_disk)
         .with(resource_group_name, disk_params)
       expect do
-        disk_manager2.create_disk(disk_id, location, size, storage_account_type, zone)
+        disk_manager2.create_disk(disk_id, location, size, storage_account_type, zone, disk_encryption_set_name: 'set_name')
       end.not_to raise_error
     end
   end
@@ -376,7 +377,8 @@ describe Bosh::AzureCloud::DiskManager2 do
           disk_name: disk_name,
           disk_size: 7,
           disk_placement: 'CacheDisk',
-          disk_caching: 'ReadOnly'
+          disk_caching: 'ReadOnly',
+          disk_encryption_set_name: nil
         )
       end
     end
@@ -402,7 +404,8 @@ describe Bosh::AzureCloud::DiskManager2 do
           disk_name: disk_name,
           disk_size: 8,
           disk_placement: nil,
-          disk_caching: 'ReadOnly'
+          disk_caching: 'ReadOnly',
+          disk_encryption_set_name: nil
         )
       end
     end
@@ -429,7 +432,8 @@ describe Bosh::AzureCloud::DiskManager2 do
           disk_name: disk_name,
           disk_size: 3,
           disk_placement: 'ResourceDisk',
-          disk_caching: 'ReadOnly'
+          disk_caching: 'ReadOnly',
+          disk_encryption_set_name: nil
         )
       end
     end
@@ -455,7 +459,8 @@ describe Bosh::AzureCloud::DiskManager2 do
           disk_name: disk_name,
           disk_size: 5,
           disk_placement: nil,
-          disk_caching: 'ReadOnly'
+          disk_caching: 'ReadOnly',
+          disk_encryption_set_name: nil
         )
       end
     end
@@ -481,7 +486,8 @@ describe Bosh::AzureCloud::DiskManager2 do
           disk_name: disk_name,
           disk_size: 5,
           disk_placement: 'CacheDisk',
-          disk_caching: 'ReadOnly'
+          disk_caching: 'ReadOnly',
+          disk_encryption_set_name: nil
         )
       end
     end
@@ -506,7 +512,8 @@ describe Bosh::AzureCloud::DiskManager2 do
           disk_name: disk_name,
           disk_size: 30,
           disk_placement: 'CacheDisk',
-          disk_caching: 'ReadOnly'
+          disk_caching: 'ReadOnly',
+          disk_encryption_set_name: nil
         )
       end
     end
@@ -532,9 +539,26 @@ describe Bosh::AzureCloud::DiskManager2 do
           disk_name: disk_name,
           disk_size: 10,
           disk_placement: 'CacheDisk',
-          disk_caching: 'ReadOnly'
+          disk_caching: 'ReadOnly',
+          disk_encryption_set_name: nil
         )
       end
+    end
+
+    it 'passes through the disk encryption set name' do
+      vm_props = props_factory.parse_vm_props(
+        'instance_type' => 'STANDARD_A1',
+      )
+
+      expect(
+        disk_manager2.ephemeral_os_disk(vm_name, stemcell_info, vm_props.root_disk.size, vm_props.ephemeral_disk.size, vm_props.ephemeral_disk.use_root_disk, vm_props.root_disk.placement, disk_encryption_set_name: 'set_name')
+      ).to eq(
+        disk_name: disk_name,
+        disk_size: nil,
+        disk_placement: nil,
+        disk_caching: 'ReadOnly',
+        disk_encryption_set_name: 'set_name'
+      )
     end
   end
 
@@ -567,7 +591,8 @@ describe Bosh::AzureCloud::DiskManager2 do
         ).to eq(
           disk_name: disk_name,
           disk_size: nil,
-          disk_caching: 'ReadWrite'
+          disk_caching: 'ReadWrite',
+          disk_encryption_set_name: nil
         )
       end
     end
@@ -588,7 +613,8 @@ describe Bosh::AzureCloud::DiskManager2 do
           ).to eq(
             disk_name: disk_name,
             disk_size: nil,
-            disk_caching: disk_caching
+            disk_caching: disk_caching,
+            disk_encryption_set_name: nil
           )
         end
       end
@@ -623,7 +649,8 @@ describe Bosh::AzureCloud::DiskManager2 do
         ).to eq(
           disk_name: disk_name,
           disk_size: nil,
-          disk_caching: 'ReadWrite'
+          disk_caching: 'ReadWrite',
+          disk_encryption_set_name: nil
         )
       end
     end
@@ -644,7 +671,8 @@ describe Bosh::AzureCloud::DiskManager2 do
             ).to eq(
               disk_name: disk_name,
               disk_size: nil,
-              disk_caching: 'ReadWrite'
+              disk_caching: 'ReadWrite',
+              disk_encryption_set_name: nil
             )
           end
         end
@@ -677,7 +705,8 @@ describe Bosh::AzureCloud::DiskManager2 do
                 ).to eq(
                   disk_name: disk_name,
                   disk_size: minimum_required_disk_size,
-                  disk_caching: 'ReadWrite'
+                  disk_caching: 'ReadWrite',
+                  disk_encryption_set_name: nil
                 )
               end
             end
@@ -696,7 +725,8 @@ describe Bosh::AzureCloud::DiskManager2 do
                 ).to eq(
                   disk_name: disk_name,
                   disk_size: image_size / 1024,
-                  disk_caching: 'ReadWrite'
+                  disk_caching: 'ReadWrite',
+                  disk_encryption_set_name: nil
                 )
               end
             end
@@ -724,7 +754,8 @@ describe Bosh::AzureCloud::DiskManager2 do
                 ).to eq(
                   disk_name: disk_name,
                   disk_size: minimum_required_disk_size,
-                  disk_caching: 'ReadWrite'
+                  disk_caching: 'ReadWrite',
+                  disk_encryption_set_name: nil
                 )
               end
             end
@@ -743,7 +774,8 @@ describe Bosh::AzureCloud::DiskManager2 do
                 ).to eq(
                   disk_name: disk_name,
                   disk_size: image_size / 1024,
-                  disk_caching: 'ReadWrite'
+                  disk_caching: 'ReadWrite',
+                  disk_encryption_set_name: nil
                 )
               end
             end
@@ -791,7 +823,8 @@ describe Bosh::AzureCloud::DiskManager2 do
             ).to eq(
               disk_name: disk_name,
               disk_size: 4,
-              disk_caching: 'ReadWrite'
+              disk_caching: 'ReadWrite',
+              disk_encryption_set_name: nil
             )
           end
         end
@@ -812,7 +845,8 @@ describe Bosh::AzureCloud::DiskManager2 do
             ).to eq(
               disk_name: disk_name,
               disk_size: 5,
-              disk_caching: 'ReadWrite'
+              disk_caching: 'ReadWrite',
+              disk_encryption_set_name: nil
             )
           end
         end
@@ -833,11 +867,26 @@ describe Bosh::AzureCloud::DiskManager2 do
             ).to eq(
               disk_name: disk_name,
               disk_size: 6,
-              disk_caching: 'ReadWrite'
+              disk_caching: 'ReadWrite',
+              disk_encryption_set_name: nil
             )
           end
         end
       end
+    end
+
+    it 'passes through the disk encryption set name' do
+      vm_props = props_factory.parse_vm_props(
+        'instance_type' => 'STANDARD_A1',
+      )
+      expect(
+        disk_manager2.os_disk(vm_name, stemcell_info, vm_props.root_disk.size, vm_props.caching, vm_props.ephemeral_disk.use_root_disk, disk_encryption_set_name: 'set_name')
+      ).to eq(
+        disk_name: disk_name,
+        disk_size: nil,
+        disk_caching: 'ReadWrite',
+        disk_encryption_set_name: 'set_name'
+      )
     end
   end
 
@@ -864,7 +913,8 @@ describe Bosh::AzureCloud::DiskManager2 do
             disk_caching: 'ReadWrite',
             disk_type: nil,
             iops: nil,
-            mbps: nil
+            mbps: nil,
+            disk_encryption_set_name: nil
           )
         end
       end
@@ -886,7 +936,8 @@ describe Bosh::AzureCloud::DiskManager2 do
             disk_caching: 'ReadWrite',
             disk_type: nil,
             iops: nil,
-            mbps: nil
+            mbps: nil,
+            disk_encryption_set_name: nil
           )
         end
       end
@@ -914,7 +965,8 @@ describe Bosh::AzureCloud::DiskManager2 do
               disk_caching: 'ReadWrite',
               disk_type: nil,
               iops: nil,
-              mbps: nil
+              mbps: nil,
+              disk_encryption_set_name: nil
             )
           end
         end
@@ -959,7 +1011,8 @@ describe Bosh::AzureCloud::DiskManager2 do
               disk_caching: 'ReadWrite',
               disk_type: 'Premium_LRS',
               iops: nil,
-              mbps: nil
+              mbps: nil,
+              disk_encryption_set_name: nil
             )
           end
         end
@@ -986,7 +1039,8 @@ describe Bosh::AzureCloud::DiskManager2 do
               disk_caching: 'None',
               disk_type: 'PremiumV2_LRS',
               iops: 5000,
-              mbps: nil
+              mbps: nil,
+              disk_encryption_set_name: nil
             )
           end
         end
@@ -1014,7 +1068,8 @@ describe Bosh::AzureCloud::DiskManager2 do
               disk_caching: 'None',
               disk_type: 'PremiumV2_LRS',
               iops: 5000,
-              mbps: 150
+              mbps: 150,
+              disk_encryption_set_name: nil
             )
           end
         end
@@ -1037,7 +1092,8 @@ describe Bosh::AzureCloud::DiskManager2 do
               disk_caching: 'ReadWrite',
               disk_type: nil,
               iops: nil,
-              mbps: nil
+              mbps: nil,
+              disk_encryption_set_name: nil
             )
           end
         end
@@ -1063,7 +1119,8 @@ describe Bosh::AzureCloud::DiskManager2 do
                 disk_caching: 'ReadWrite',
                 disk_type: nil,
                 iops: nil,
-                mbps: nil
+                mbps: nil,
+                disk_encryption_set_name: nil
               )
             end
           end
@@ -1085,6 +1142,27 @@ describe Bosh::AzureCloud::DiskManager2 do
               end.to raise_error ArgumentError, "The disk size needs to be an integer. The current value is 'invalid-size'."
             end
           end
+        end
+
+        it 'passes through the disk encryption set name' do
+          vm_props = props_factory.parse_vm_props(
+            'instance_type' => 'STANDARD_A1',
+            'ephemeral_disk' => {
+              'disk_encryption_set_name' => 'set_name'
+            }
+          )
+          expect(
+            disk_manager2.ephemeral_disk(vm_name, vm_props.instance_type, vm_props.ephemeral_disk.size, vm_props.ephemeral_disk.type, vm_props.ephemeral_disk.use_root_disk,
+              vm_props.ephemeral_disk.caching, vm_props.ephemeral_disk.iops, vm_props.ephemeral_disk.mbps, disk_encryption_set_name: vm_props.ephemeral_disk.disk_encryption_set_name)
+          ).to eq(
+            disk_name: disk_name,
+            disk_size: default_ephemeral_disk_size,
+            disk_caching: 'ReadWrite',
+            disk_type: nil,
+            iops: nil,
+            mbps: nil,
+            disk_encryption_set_name: 'set_name'
+          )
         end
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/models/vm_cloud_props_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/models/vm_cloud_props_spec.rb
@@ -472,6 +472,44 @@ describe Bosh::AzureCloud::VMCloudProps do
           expect(root_disk.placement).to eq('cache-disk')
         end
       end
+
+      context 'with disk_encryption_set_name' do
+        let(:vm_cloud_props) do
+          Bosh::AzureCloud::VMCloudProps.new(
+            {
+              'instance_type' => 'Standard_D1',
+              'root_disk' => {
+                'disk_encryption_set_name' => 'set_name'
+              }
+            }, azure_config_managed
+          )
+        end
+
+        it 'captures the config correctly' do
+          root_disk = vm_cloud_props.root_disk
+          expect(root_disk.disk_encryption_set_name).to eq('set_name')
+        end
+      end
+    end
+
+    context 'when ephemeral disk is specified' do
+      context 'with disk_encryption_set_name' do
+        let(:vm_cloud_props) do
+          Bosh::AzureCloud::VMCloudProps.new(
+            {
+              'instance_type' => 'Standard_D1',
+              'ephemeral_disk' => {
+                'disk_encryption_set_name' => 'set_name'
+              }
+            }, azure_config_managed
+          )
+        end
+
+        it 'captures the config correctly' do
+          ephemeral_disk = vm_cloud_props.ephemeral_disk
+          expect(ephemeral_disk.disk_encryption_set_name).to eq('set_name')
+        end
+      end
     end
 
     describe '#managed_identity' do


### PR DESCRIPTION
The disk encryption set name can be provided in cloud properties for a persistent disk or when a VM is created to configure the encryption for the os or ephemeral disks.

Also updated the documentation for migrating unmanaged to managed disks that was done as part of #708

New cloud properties will be documented in a different PR against the docs-bosh repo.