### PR TITLE
Allow capcity reservation groups in `create_vm`

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -166,7 +166,7 @@ module Bosh::AzureCloud
 
           agent_settings = Bosh::AzureCloud::BoshAgentUtil.new
 
-          instance_id, vm_params = @vm_manager.create(
+          instance_id, _ = @vm_manager.create(
             bosh_vm_meta,
             location,
             vm_props,

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
@@ -18,6 +18,7 @@ module Bosh::AzureCloud
     attr_reader :storage_account_name, :storage_account_type, :storage_account_kind, :storage_account_max_disk_number
     attr_reader :resource_group_name
     attr_reader :tags
+    attr_reader :capacity_reservation_group
 
     # Below defines are for test purpose
     # NOTE: The following 3 attr_writer (and their paired readers above) are explicitly separate (instead of using `attr_accessor`)
@@ -93,6 +94,8 @@ module Bosh::AzureCloud
 
       @resource_group_name = vm_properties.fetch('resource_group_name', global_azure_config.resource_group_name)
       @tags = vm_properties.fetch('tags', {})
+
+      @capacity_reservation_group = vm_properties['capacity_reservation_group']
     end
 
     private

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -336,6 +336,19 @@ module Bosh::AzureCloud
         }
       }
 
+      capacity_reservation_group_id = vm_params[:capacity_reservation_group]
+      unless capacity_reservation_group_id.nil?
+        unless vm_params[:capacity_reservation_group].start_with?('/subscriptions')
+          capacity_reservation_group_id = rest_api_url(REST_API_PROVIDER_COMPUTE, 'capacityReservationGroups', resource_group_name: resource_group_name, name: vm_params[:capacity_reservation_group])
+        end
+
+        vm['properties']['capacityReservation'] = {
+          'capacityReservationGroup' => {
+            'id' => capacity_reservation_group_id
+          }
+        }
+      end
+
       unless vm_params[:identity].nil?
         identity_type = vm_params[:identity][:type]
         if identity_type == MANAGED_IDENTITY_TYPE_USER_ASSIGNED

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -336,15 +336,10 @@ module Bosh::AzureCloud
         }
       }
 
-      capacity_reservation_group_id = vm_params[:capacity_reservation_group]
-      unless capacity_reservation_group_id.nil?
-        unless vm_params[:capacity_reservation_group].start_with?('/subscriptions')
-          capacity_reservation_group_id = rest_api_url(REST_API_PROVIDER_COMPUTE, 'capacityReservationGroups', resource_group_name: resource_group_name, name: vm_params[:capacity_reservation_group])
-        end
-
+      unless vm_params[:capacity_reservation_group].nil?
         vm['properties']['capacityReservation'] = {
           'capacityReservationGroup' => {
-            'id' => capacity_reservation_group_id
+            'id' => rest_api_url(REST_API_PROVIDER_COMPUTE, 'capacityReservationGroups', resource_group_name: resource_group_name, name: vm_params[:capacity_reservation_group])
           }
         }
       end

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
@@ -131,6 +131,10 @@ module Bosh::AzureCloud
         managed: @use_managed_disks
       }
 
+      unless vm_props.capacity_reservation_group.nil?
+        vm_params[:capacity_reservation_group] = vm_props.capacity_reservation_group
+      end
+
       unless vm_props.managed_identity.nil?
         vm_params[:identity] = {
           type: vm_props.managed_identity.type,

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_virtual_machine_spec.rb
@@ -498,6 +498,11 @@ describe Bosh::AzureCloud::AzureClient do
             }
           }
         end
+        let(:vm_params_with_crg_name) do
+          vm_params_dupped = vm_params.dup
+          vm_params_dupped[:capacity_reservation_group] = capacity_reservation_group_name
+          vm_params_dupped
+        end
 
         before do
           stub_request(:post, token_uri).to_return(
@@ -522,32 +527,10 @@ describe Bosh::AzureCloud::AzureClient do
           )
         end
 
-        context 'when capacity_reservation_group is a full resource ID' do
-          let(:vm_params_with_crg) do
-            vm_params_dupped = vm_params.dup
-            vm_params_dupped[:capacity_reservation_group] = capacity_reservation_group_id
-            vm_params_dupped
-          end
-
-          it 'should create the vm with capacity reservation group' do
-            expect do
-              azure_client.create_virtual_machine(resource_group, vm_params_with_crg, network_interfaces)
-            end.not_to raise_error
-          end
-        end
-
-        context 'when capacity_reservation_group is just the name' do
-          let(:vm_params_with_crg_name) do
-            vm_params_dupped = vm_params.dup
-            vm_params_dupped[:capacity_reservation_group] = capacity_reservation_group_name
-            vm_params_dupped
-          end
-
-          it 'should construct the full ID and create the vm with capacity reservation group' do
-            expect do
-              azure_client.create_virtual_machine(resource_group, vm_params_with_crg_name, network_interfaces)
-            end.not_to raise_error
-          end
+        it 'should construct the full ID and create the vm with capacity reservation group' do
+          expect do
+            azure_client.create_virtual_machine(resource_group, vm_params_with_crg_name, network_interfaces)
+          end.not_to raise_error
         end
       end
 

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_virtual_machine_spec.rb
@@ -416,6 +416,141 @@ describe Bosh::AzureCloud::AzureClient do
         end
       end
 
+      context 'when capacity_reservation_group is set' do
+        let(:capacity_reservation_group_name) { 'fake-crg-name' }
+        let(:capacity_reservation_group_id) { "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Compute/capacityReservationGroups/#{capacity_reservation_group_name}" }
+        let(:request_body) do
+          {
+            name: vm_name,
+            location: 'b',
+            type: 'Microsoft.Compute/virtualMachines',
+            tags: {
+              foo: 'bar'
+            },
+            properties: {
+              hardwareProfile: {
+                vmSize: 'c'
+              },
+              osProfile: {
+                customData: 'f',
+                computerName: vm_name,
+                adminUsername: 'd',
+                linuxConfiguration: {
+                  disablePasswordAuthentication: 'true',
+                  ssh: {
+                    publicKeys: [
+                      {
+                        path: '/home/d/.ssh/authorized_keys',
+                        keyData: 'e'
+                      }
+                    ]
+                  }
+                }
+              },
+              networkProfile: {
+                networkInterfaces: [
+                  {
+                    id: 'a',
+                    properties: {
+                      primary: true
+                    }
+                  },
+                  {
+                    id: 'b',
+                    properties: {
+                      primary: false
+                    }
+                  }
+                ]
+              },
+              storageProfile: {
+                osDisk: {
+                  name: 'h',
+                  osType: 'linux',
+                  createOption: 'FromImage',
+                  caching: 'j',
+                  image: {
+                    uri: 'g'
+                  },
+                  vhd: {
+                    uri: 'i'
+                  },
+                  diskSizeGB: 'k'
+                },
+                dataDisks: [
+                  {
+                    name: 'l',
+                    lun: 0,
+                    createOption: 'Empty',
+                    diskSizeGB: 'o',
+                    vhd: {
+                      uri: 'm'
+                    },
+                    caching: 'n'
+                  }
+                ]
+              },
+              capacityReservation: {
+                capacityReservationGroup: {
+                  id: capacity_reservation_group_id
+                }
+              }
+            }
+          }
+        end
+
+        before do
+          stub_request(:post, token_uri).to_return(
+            status: 200,
+            body: {
+              'access_token' => valid_access_token,
+              'expires_on' => expires_on
+            }.to_json,
+            headers: {}
+          )
+          stub_request(:put, vm_uri).with(body: request_body).to_return(
+            status: 200,
+            body: '',
+            headers: {
+              'azure-asyncoperation' => operation_status_link
+            }
+          )
+          stub_request(:get, operation_status_link).to_return(
+            status: 200,
+            body: '{"status":"Succeeded"}',
+            headers: {}
+          )
+        end
+
+        context 'when capacity_reservation_group is a full resource ID' do
+          let(:vm_params_with_crg) do
+            vm_params_dupped = vm_params.dup
+            vm_params_dupped[:capacity_reservation_group] = capacity_reservation_group_id
+            vm_params_dupped
+          end
+
+          it 'should create the vm with capacity reservation group' do
+            expect do
+              azure_client.create_virtual_machine(resource_group, vm_params_with_crg, network_interfaces)
+            end.not_to raise_error
+          end
+        end
+
+        context 'when capacity_reservation_group is just the name' do
+          let(:vm_params_with_crg_name) do
+            vm_params_dupped = vm_params.dup
+            vm_params_dupped[:capacity_reservation_group] = capacity_reservation_group_name
+            vm_params_dupped
+          end
+
+          it 'should construct the full ID and create the vm with capacity reservation group' do
+            expect do
+              azure_client.create_virtual_machine(resource_group, vm_params_with_crg_name, network_interfaces)
+            end.not_to raise_error
+          end
+        end
+      end
+
       context 'when managed is true' do
         before do
           vm_params.delete(:image_uri)

--- a/src/bosh_azure_cpi/spec/unit/models/vm_cloud_props_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/models/vm_cloud_props_spec.rb
@@ -589,5 +589,35 @@ describe Bosh::AzureCloud::VMCloudProps do
         end
       end
     end
+
+    context 'when capacity_reservation_group is specified' do
+      let(:crg_name) { 'fake-crg-name' }
+      let(:vm_cloud_props) do
+        Bosh::AzureCloud::VMCloudProps.new(
+          {
+            'instance_type' => 'Standard_D1',
+            'capacity_reservation_group' => crg_name
+          }, azure_config_managed
+        )
+      end
+
+      it 'captures the config correctly' do
+        expect(vm_cloud_props.capacity_reservation_group).to eq(crg_name)
+      end
+    end
+
+    context 'when capacity_reservation_group is not specified' do
+      let(:vm_cloud_props) do
+        Bosh::AzureCloud::VMCloudProps.new(
+          {
+            'instance_type' => 'Standard_D1'
+          }, azure_config_managed
+        )
+      end
+
+      it 'should be nil' do
+        expect(vm_cloud_props.capacity_reservation_group).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
# Summary

As a BOSH user I would like to be able to use [on-demand capacity reservation](https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-overview) when provisioning vms on Azure. On-demand capacity reservation in Azure allows you to reserve compute capacity in a specific region or availability zone for any duration without committing to a long-term contract. This means you can create and delete reservations as needed, giving you flexibility in managing your resources.

# Details

When `capacity_reservation_groups` are specified in the cloud-properties of a vm type / extension, the group is referenced in api call when creating / updating vms.

# Validation

To test my changes, I deployed a BOSH director using my branch of the bosh-azure-cpi and uploaded a cloud-config with the following configuration:

```diff
  vm_types:
  - name: vm_2cpu_8gb
    instance_type: Standard_B2as_v2
    cloud_properties:
+     capacity_reservation_group: sh-b-series
```

On Azure I created a capacity reservation group named `sh-b-series`.

<img width="1089" alt="Screenshot1" src="https://github.com/user-attachments/assets/9339a128-4b08-4ea3-86b6-a9572fe18073" />

Then, I deployed a VM using the `vm_2cpu_8gb` vm type. Notice the `capacity_reservation_group` is passed via the cloud_properties:

```sh
$ bosh task 172 --cpi | grep 'create_vm('
I, [2025-04-14T11:33:25.112354 #2358261 #2440] INFO -- [req_id cpi-961083]: create_vm(39727fb9-890d-489f-a36a-00fae580bf0f, bosh-stemcell-75f01dff-0b5e-4d75-8c48-814b83a55473, {"availability_zone"=>"1", "accelerated_networking"=>false, "capacity_reservation_group"=>"sh-b-series", "ephemeral_disk"=>{"caching"=>"None", "size"=>18432, "type"=>"PremiumV2_LRS"}, "instance_type"=>"Standard_B2as_v2", "storage_account_type"=>"Standard_LRS"}, {"default"=>{"type"=>"manual", "ip"=>"10.1.8.0", "netmask"=>"255.255.0.0", "cloud_properties"=>{"application_security_groups"=>["asg-v2-bosh-dns"], "subnet_name"=>"platform_z1", "virtual_network_name"=>"vnet-sh-gallery"}, "default"=>["dns", "gateway"], "dns"=>["168.63.129.16"], "gateway"=>"10.1.0.1"}}, [], ...)
```

Also, the `capacityReservationGroup` can be seen in the API calls (count to redact credentials):

```sh
$ bosh task 172 --cpi | grep capacityReservationGroup | wc -l
13
```

In the Azure Portal you can see that the provisioned VM is using the capacity reservation group `sh-b-series`:

<img width="1042" alt="Screenshot2" src="https://github.com/user-attachments/assets/616780e5-7eea-4891-988f-e04676251efa" />


# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero errors (after my changes)

Please include below the summary portions of the output from the following 2 scripts:

  ```
  pushd src/bosh_azure_cpi
    bundle install
    bundle exec rake spec:unit
    bundle exec rake rubocop
  popd
  ```

  _NOTE:_ Please see how to setup dev environment and run unit tests in docs/development.md.

### Unit Test output:

```sh
$ bundle exec rake spec:unit
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................../workspaces/bosh-azure-cpi-release/src/bosh_azure_cpi/vendor/package/ruby/3.3.0/gems/azure-storage-table-2.0.4/lib/azure/storage/table/table_service.rb:30: warning: already initialized constant Azure::Storage::StorageService
/workspaces/bosh-azure-cpi-release/src/bosh_azure_cpi/vendor/package/ruby/3.3.0/gems/azure-storage-blob-2.0.3/lib/azure/storage/blob/blob_service.rb:33: warning: previous definition of StorageService was here
............................................................................................................................................................................................................................................................

Finished in 5.82 seconds (files took 6.36 seconds to load)
1095 examples, 0 failures

Coverage report generated for RSpec to /workspaces/bosh-azure-cpi-release/src/bosh_azure_cpi/coverage.
Line Coverage: 49.45% (20239 / 40929)
```

### Rubocop output:

No offenses in the files I touched.

# Changelog

* Allow the usage of on-demand capacity reservation when managing vms
