### PR TITLE
CI: update references for terraform to be correct

### DIFF
--- a/ci/assets/terraform/az_bats/terraform.tf
+++ b/ci/assets/terraform/az_bats/terraform.tf
@@ -84,13 +84,13 @@ resource "azurerm_storage_account" "azure_bosh_sa" {
 # Create a Storage Container for the bosh director
 resource "azurerm_storage_container" "azure_bosh_container" {
   name                  = "bosh"
-  storage_account_id  = azurerm_storage_account.azure_bosh_sa.name
+  storage_account_id    = azurerm_storage_account.azure_bosh_sa.id
   container_access_type = "private"
 }
 # Create a Storage Container for the stemcells
 resource "azurerm_storage_container" "azure_stemcell_container" {
   name                  = "stemcell"
-  storage_account_id  = azurerm_storage_account.azure_bosh_sa.name
+  storage_account_id    = azurerm_storage_account.azure_bosh_sa.id
   container_access_type = "blob"
 }
 

--- a/ci/assets/terraform/integration/template.tf
+++ b/ci/assets/terraform/integration/template.tf
@@ -80,13 +80,13 @@ resource "azurerm_storage_account" "azure_bosh_sa" {
 # Create a Storage Container for the disks
 resource "azurerm_storage_container" "azure_bosh_container" {
   name                  = "bosh"
-  storage_account_id  = azurerm_storage_account.azure_bosh_sa.name
+  storage_account_id    = azurerm_storage_account.azure_bosh_sa.id
   container_access_type = "private"
 }
 # Create a Storage Container for the stemcells
 resource "azurerm_storage_container" "azure_stemcell_container" {
   name                  = "stemcell"
-  storage_account_id  = azurerm_storage_account.azure_bosh_sa.name
+  storage_account_id    = azurerm_storage_account.azure_bosh_sa.id
   container_access_type = "blob"
 }
 # Create a Storage Table for the metadata of the stemcells


### PR DESCRIPTION
When correcting the terraform deprecations I changed the value set (storage_account_name -> storage_account_id) but not the value extracted (.name -> .id). This commit addresses that error.

