### PR TITLE
Fix failing gallery integration test

### DIFF
--- a/src/bosh_azure_cpi/spec/integration/stemcell_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/stemcell_spec.rb
@@ -76,7 +76,7 @@ describe Bosh::AzureCloud::Cloud do
           cpi_gallery.stemcell_manager2.get_user_image_info(@stemcell_id, 'Standard_LRS', other_location)
 
           # Verify image replication
-          gallery_image = azure_client.get_gallery_image_version_by_tags(@compute_gallery_name, {'stemcell_name' => @stemcell_id})
+          gallery_image = azure_client.get_gallery_image_version_by_stemcell_name(@compute_gallery_name, @stemcell_id)
           expect(gallery_image).not_to be_nil
           expect(gallery_image[:replica_count]).to eq(1)
           actual_regions = gallery_image[:target_regions].map { |region| region.downcase.gsub(' ', '') }
@@ -87,7 +87,7 @@ describe Bosh::AzureCloud::Cloud do
           cpi_gallery.delete_stemcell(@stemcell_id)
 
           # Verify gallery image version was deleted
-          deleted_image = azure_client.get_gallery_image_version_by_tags(@compute_gallery_name, {'stemcell_name' => @stemcell_id})
+          deleted_image = azure_client.get_gallery_image_version_by_stemcell_name(@compute_gallery_name, @stemcell_id)
           expect(deleted_image).to be_nil
           @stemcell_id = nil
         end


### PR DESCRIPTION
This change fixes an issue with a Compute Gallery related integeration test. The issue is caused by #721, which replaced the `get_gallery_image_version_by_tags` method with `get_gallery_image_version_by_stemcell_name`.

The error:

```sh
  1) Bosh::AzureCloud::Cloud#stemcell with heavy stemcell when compute gallery is configured should create gallery image definition and version
     Failure/Error: gallery_image = azure_client.get_gallery_image_version_by_tags(@compute_gallery_name, {'stemcell_name' => @stemcell_id})
     
     NoMethodError:
       undefined method `get_gallery_image_version_by_tags' for an instance of Bosh::AzureCloud::AzureClient
     # ./spec/integration/stemcell_spec.rb:79:in `block (5 levels) in <top (required)>'
     # /usr/local/bundle/ruby/3.3.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # /usr/local/bundle/ruby/3.3.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # /usr/local/bundle/ruby/3.3.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # /usr/local/bundle/ruby/3.3.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup' 
```