### PR TITLE
Use new storageAccountId property for creating ACG versions

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -2165,7 +2165,7 @@ module Bosh::AzureCloud
         properties['storageProfile'] = {
           'osDiskImage' => {
             'source' => {
-              'id' => rest_api_url(REST_API_PROVIDER_STORAGE, 'storageAccounts', name: params['storage_account_name']),
+              'storageAccountId' => rest_api_url(REST_API_PROVIDER_STORAGE, 'storageAccounts', name: params['storage_account_name']),
               'uri' => params['blob_uri']
             }
           }


### PR DESCRIPTION
# Summary

Microsoft deprecated the use of `properties.storageProfile.[osDiskImage/dataDiskImages].source.Id` when creating ACG image versions. It is replaced by `properties.storageProfile.osDiskImage.source.storageAccountId`.

# Checklist

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero errors (after my changes)

# Changelog

* The deprecated property `properties.storageProfile.[osDiskImage/dataDiskImages].source.Id` is replaced by `properties.storageProfile.osDiskImage.source.storageAccountId`, when creating ACG image versions.
