### PR TITLE
IPv6 dual-stack support for Azure VMs

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/config.rb
@@ -3,16 +3,17 @@
 module Bosh::AzureCloud
   # TODO: Refactoring: Move class to new file: LoadBalancerConfig
   class LoadBalancerConfig
-    attr_reader :name, :resource_group_name, :backend_pool_name
+    attr_reader :name, :resource_group_name, :backend_pool_name, :backend_pool_name_v6
 
-    def initialize(resource_group_name, name, backend_pool_name = nil)
+    def initialize(resource_group_name, name, backend_pool_name = nil, backend_pool_name_v6 = nil)
       @resource_group_name = resource_group_name
       @name = name
       @backend_pool_name = backend_pool_name
+      @backend_pool_name_v6 = backend_pool_name_v6
     end
 
     def to_s
-      "name: #{@name}, resource_group_name: #{@resource_group_name}, backend_pool_name: #{@backend_pool_name}"
+      "name: #{@name}, resource_group_name: #{@resource_group_name}, backend_pool_name: #{@backend_pool_name}, backend_pool_name_v6: #{@backend_pool_name_v6}"
     end
   end
 

--- a/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/models/vm_cloud_props.rb
@@ -32,6 +32,7 @@ module Bosh::AzureCloud
     LOAD_BALANCER_KEY = 'load_balancer'
     APPLICATION_GATEWAY_KEY = 'application_gateway'
     BACKEND_POOL_NAME_KEY = 'backend_pool_name'
+    BACKEND_POOL_NAME_V6_KEY = 'backend_pool_name_v6'
     RESOURCE_GROUP_NAME_KEY = 'resource_group_name'
     NAME_KEY = 'name'
 
@@ -148,16 +149,19 @@ module Bosh::AzureCloud
           load_balancer_names = lbc[NAME_KEY]
           resource_group_name = lbc[RESOURCE_GROUP_NAME_KEY]
           backend_pool_name = lbc[BACKEND_POOL_NAME_KEY]
+          backend_pool_name_v6 = lbc[BACKEND_POOL_NAME_V6_KEY]
         else
           load_balancer_names = lbc
           resource_group_name = nil
           backend_pool_name = nil
+          backend_pool_name_v6 = nil
         end
         String(load_balancer_names).split(',').map do |load_balancer_name|
           Bosh::AzureCloud::LoadBalancerConfig.new(
             resource_group_name || global_azure_config.resource_group_name,
             load_balancer_name,
-            backend_pool_name
+            backend_pool_name,
+            backend_pool_name_v6
           )
         end
       end

--- a/src/bosh_azure_cpi/lib/cloud/azure/network/network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/network/network.rb
@@ -2,7 +2,7 @@
 
 module Bosh::AzureCloud
   class Network
-    attr_reader :resource_group_name
+    attr_reader :resource_group_name, :nic_group
     attr_reader :spec
 
     RESOURCE_GROUP_NAME_KEY = 'resource_group_name'
@@ -24,6 +24,7 @@ module Bosh::AzureCloud
       @ip = spec['ip']
       @cloud_properties = spec['cloud_properties']
       @spec = spec
+      @nic_group = spec['nic_group'] || name
       @resource_group_name = if @cloud_properties.nil? || @cloud_properties[RESOURCE_GROUP_NAME_KEY].nil?
                                @azure_config.resource_group_name
                              else

--- a/src/bosh_azure_cpi/lib/cloud/azure/network/network_configurator.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/network/network_configurator.rb
@@ -15,7 +15,7 @@ module Bosh::AzureCloud
   class NetworkConfigurator
     include Helpers
 
-    attr_reader :vip_network, :networks
+    attr_reader :vip_network, :networks, :nic_groups
     attr_accessor :logger
 
     ##
@@ -73,6 +73,8 @@ module Bosh::AzureCloud
       end
 
       cloud_error('At least one dynamic or manual network must be defined') if @networks.empty?
+
+      @nic_groups = _compute_nic_groups(@networks)
     end
 
     # For multiple networks, use the default dns specified in spec.
@@ -83,6 +85,34 @@ module Bosh::AzureCloud
         return network.dns if network.has_default_dns?
       end
       @networks[0].dns
+    end
+
+    private
+
+    # Group networks by nic_group. Networks sharing the same nic_group value
+    # are placed on the same NIC (with multiple ipConfigurations).
+    # The primary network's group always comes first.
+    #
+    # @return [Array<Array<Network>>] each inner array = one NIC's networks
+    def _compute_nic_groups(networks)
+      primary = networks[0]
+      groups = { primary.nic_group => [primary] }
+      networks.drop(1).each do |network|
+        groups[network.nic_group] ||= []
+        groups[network.nic_group] << network
+      end
+
+      groups.each do |nic_group, group_networks|
+        subnets = group_networks.map do |network|
+          [network.resource_group_name, network.virtual_network_name, network.subnet_name]
+        end.uniq
+        next if subnets.one?
+
+        subnet_names = subnets.map { |resource_group, virtual_network, subnet| "#{resource_group}/#{virtual_network}/#{subnet}" }
+        cloud_error("Networks in nic_group '#{nic_group}' must use the same Azure subnet: #{subnet_names.join(', ')}")
+      end
+
+      groups.values
     end
   end
 end

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -2445,6 +2445,7 @@ module Bosh::AzureCloud
       public_ip = nic_params[:public_ip]
       public_ip_version = public_ip && (public_ip[:public_ip_address_version] || 'IPv4')
       public_ip_attached = false
+      nat_rules_attached_by_ip_version = {}
 
       if public_ip && ip_configurations.none? { |ipconfig| (ipconfig[:ip_version] || 'IPv4') == public_ip_version }
         raise AzureError, "create_network_interface - no ipConfiguration matches the public IP address version '#{public_ip_version}' for network interface '#{nic_params[:name]}'"
@@ -2479,23 +2480,26 @@ module Bosh::AzureCloud
                           .map { |pools| { 'id' => pools[0][:id] } }
           config_properties['loadBalancerBackendAddressPools'] = backend_pools unless backend_pools.empty?
 
-          inbound_nat_rules = nic_params[:load_balancers].flat_map do |lb|
-            frontends = lb[:frontend_ip_configurations]
-            next [] if frontends.nil?
+          unless nat_rules_attached_by_ip_version[ip_version]
+            inbound_nat_rules = nic_params[:load_balancers].flat_map do |lb|
+              frontends = lb[:frontend_ip_configurations]
+              next [] if frontends.nil?
 
-            frontends = [frontends] unless frontends.is_a?(Array)
-            frontends.select do |frontend|
-              frontend_ip_version = frontend[:private_ip_address_version] ||
-                                    frontend.dig(:public_ip, :public_ip_address_version) ||
-                                    'IPv4'
-              frontend_ip_version == ip_version
-            end.flat_map { |frontend| frontend[:inbound_nat_rules] || [] }
-          end.compact
-          config_properties['loadBalancerInboundNatRules'] = inbound_nat_rules unless inbound_nat_rules.empty?
+              frontends = [frontends] unless frontends.is_a?(Array)
+              frontends.select do |frontend|
+                frontend_ip_version = frontend[:private_ip_address_version] ||
+                                      frontend.dig(:public_ip, :public_ip_address_version) ||
+                                      'IPv4'
+                frontend_ip_version == ip_version
+              end.flat_map { |frontend| frontend[:inbound_nat_rules] || [] }
+            end.compact
+            config_properties['loadBalancerInboundNatRules'] = inbound_nat_rules unless inbound_nat_rules.empty?
+            nat_rules_attached_by_ip_version[ip_version] = true
+          end
         end
 
-        # Application gateways - IPv4 backend only, as it does NOT support IPv6 backends
-        if ip_version == 'IPv4' && nic_params[:application_gateways]
+        # Application gateways - preserve legacy placement on the primary IPv4 ipConfig.
+        if is_primary && ip_version == 'IPv4' && nic_params[:application_gateways]
           # NOTE: backend_address_pools[0] should always be used.
           # When `application_gateway/backend_pool_name` is specified, the named pool will always be first here.
           agw_backend_pools = nic_params[:application_gateways]

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -1518,6 +1518,7 @@ module Bosh::AzureCloud
           ip[:id]                           = frontend_ip['id']
           ip[:provisioning_state]           = frontend_ip['properties']['provisioningState']
           ip[:private_ip_allocation_method] = frontend_ip['properties']['privateIPAllocationMethod']
+          ip[:private_ip_address_version]   = frontend_ip['properties']['privateIPAddressVersion'] unless frontend_ip['properties']['privateIPAddressVersion'].nil?
           ip[:private_ip]                   = frontend_ip['properties']['privateIPAddress'] unless frontend_ip['properties']['privateIPAddress'].nil?
           ip[:public_ip]                    = get_public_ip(frontend_ip['properties']['publicIPAddress']['id']) unless frontend_ip['properties']['publicIPAddress'].nil?
           ip[:inbound_nat_rules]            = frontend_ip['properties']['inboundNatRules']
@@ -2478,12 +2479,19 @@ module Bosh::AzureCloud
                           .map { |pools| { 'id' => pools[0][:id] } }
           config_properties['loadBalancerBackendAddressPools'] = backend_pools unless backend_pools.empty?
 
-          if ip_version == 'IPv4'
-            inbound_nat_rules = nic_params[:load_balancers]
-                                .flat_map { |lb| lb[:frontend_ip_configurations]&.first&.dig(:inbound_nat_rules) }
-                                .compact
-            config_properties['loadBalancerInboundNatRules'] = inbound_nat_rules unless inbound_nat_rules.empty?
-          end
+          inbound_nat_rules = nic_params[:load_balancers].flat_map do |lb|
+            frontends = lb[:frontend_ip_configurations]
+            next [] if frontends.nil?
+
+            frontends = [frontends] unless frontends.is_a?(Array)
+            frontends.select do |frontend|
+              frontend_ip_version = frontend[:private_ip_address_version] ||
+                                    frontend.dig(:public_ip, :public_ip_address_version) ||
+                                    'IPv4'
+              frontend_ip_version == ip_version
+            end.flat_map { |frontend| frontend[:inbound_nat_rules] || [] }
+          end.compact
+          config_properties['loadBalancerInboundNatRules'] = inbound_nat_rules unless inbound_nat_rules.empty?
         end
 
         # Application gateways - IPv4 backend only, as it does NOT support IPv6 backends

--- a/src/bosh_azure_cpi/lib/cloud/azure/utils/bosh_agent_util.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/utils/bosh_agent_util.rb
@@ -23,8 +23,8 @@ module Bosh::AzureCloud
     #   }
     # }
     #
-    def encoded_user_data(instance_id, dns, agent_id, network_spec, environment, vm_params, config, computer_name = nil)
-      user_data = user_data_obj(instance_id, dns, agent_id, network_spec, environment, vm_params, config, computer_name)
+    def encoded_user_data(instance_id, dns, agent_id, network_spec, environment, vm_params, config, computer_name = nil, nic_groups_to_iface = {})
+      user_data = user_data_obj(instance_id, dns, agent_id, network_spec, environment, vm_params, config, computer_name, nic_groups_to_iface)
       Base64.strict_encode64(JSON.dump(user_data))
     end
 
@@ -37,7 +37,7 @@ module Bosh::AzureCloud
     # The agent settings are written directly to the VM's custom data.
     # The stemcell API version is used to determine compatibility with the agent on the stemcell.
     # The agent will read the base metadata, and additionally the agent settings
-    def user_data_obj(instance_id, dns, agent_id, network_spec, environment, vm_params, config, computer_name = nil)
+    def user_data_obj(instance_id, dns, agent_id, network_spec, environment, vm_params, config, computer_name = nil, nic_groups_to_iface = {})
       user_data = { }
       if computer_name
         user_data[:'instance-id'] = instance_id
@@ -47,7 +47,7 @@ module Bosh::AzureCloud
       end
       user_data[:dns] = { nameserver: dns } if dns
 
-      user_data.merge!(initial_agent_settings(agent_id, network_spec, environment, vm_params, config))
+      user_data.merge!(initial_agent_settings(agent_id, network_spec, environment, vm_params, config, nic_groups_to_iface))
 
       user_data
     end
@@ -74,13 +74,13 @@ module Bosh::AzureCloud
     # @param [Hash] environment
     # @param [Hash] vm_params
     # @return [Hash]
-    def initial_agent_settings(agent_id, network_spec, environment, vm_params, config)
+    def initial_agent_settings(agent_id, network_spec, environment, vm_params, config, nic_groups_to_iface = {})
       settings = {
         'vm' => {
           'name' => vm_params[:name]
         },
         'agent_id' => agent_id,
-        'networks' => _agent_network_spec(network_spec),
+        'networks' => _agent_network_spec(network_spec, nic_groups_to_iface),
         'disks' => {
           'system' => '/dev/sda',
           'persistent' => {}
@@ -101,10 +101,22 @@ module Bosh::AzureCloud
 
     private
 
-    def _agent_network_spec(network_spec)
+    # Build agent network spec with DHCP and optional interface alias.
+    #
+    # When nic_groups_to_iface is provided (dual-stack deployments), networks
+    # whose spec contains a 'nic_group' key are annotated with an 'alias' field
+    # (e.g. "eth0") so the bosh-agent can map multiple networks to the same OS
+    # interface without needing a MAC address (which Azure does not provide at
+    # NIC creation time).
+    def _agent_network_spec(network_spec, nic_groups_to_iface = {})
       Hash[*network_spec.map do |name, settings|
-        settings['use_dhcp'] = true
-        [name, settings]
+        normalized_settings = settings.dup
+        normalized_settings['use_dhcp'] = true
+        nic_group = normalized_settings['nic_group']
+        if nic_group && nic_groups_to_iface[nic_group]
+          normalized_settings['alias'] = nic_groups_to_iface[nic_group]
+        end
+        [name, normalized_settings]
       end.flatten]
     end
   end

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
@@ -161,7 +161,8 @@ module Bosh::AzureCloud
       when 'linux'
         vm_params[:ssh_username]  = @azure_config.ssh_user
         vm_params[:ssh_cert_data] = @azure_config.ssh_public_key
-        user_data = agent_settings.user_data_obj(instance_id.to_s, network_configurator.default_dns, bosh_vm_meta.agent_id, network_spec, env, vm_params, config)
+        nic_groups_to_iface = _build_nic_groups_to_iface(network_configurator)
+        user_data = agent_settings.user_data_obj(instance_id.to_s, network_configurator.default_dns, bosh_vm_meta.agent_id, network_spec, env, vm_params, config, nil, nic_groups_to_iface)
         vm_params[:custom_data] = agent_settings.encode_user_data(user_data)
       when 'windows'
         # Generate secure random strings as username and password for Windows VMs
@@ -184,7 +185,8 @@ module Bosh::AzureCloud
         vm_params[:windows_password] = "#{SecureRandom.uuid}#{SecureRandom.uuid.upcase}".chars.shuffle.join
         computer_name = generate_windows_computer_name
         vm_params[:computer_name] = computer_name
-        vm_params[:custom_data]   = agent_settings.encoded_user_data(instance_id.to_s, network_configurator.default_dns, bosh_vm_meta.agent_id, network_spec, env, vm_params, config, computer_name)
+        nic_groups_to_iface = _build_nic_groups_to_iface(network_configurator)
+        vm_params[:custom_data]   = agent_settings.encoded_user_data(instance_id.to_s, network_configurator.default_dns, bosh_vm_meta.agent_id, network_spec, env, vm_params, config, computer_name, nic_groups_to_iface)
       end
 
       vm_params[:diag_storage_uri] = diagnostics_storage_account[:storage_blob_host] unless diagnostics_storage_account.nil?
@@ -591,6 +593,25 @@ module Bosh::AzureCloud
 
       # If resource group does not exist, create it
       @azure_client.create_resource_group(resource_group_name, location)
+    end
+
+    # Map each explicit nic_group to its OS interface name (eth0, eth1, ...),
+    # matching the NIC attachment order used by _create_network_interfaces.
+    # The bosh-agent uses this alias to bind networks to interfaces since Azure
+    # only assigns MACs after VM start. Groups without an explicit nic_group
+    # are omitted; single-stack VMs rely on the agent's 1-net-1-iface fallback.
+    #
+    # @param network_configurator [NetworkConfigurator]
+    # @return [Hash{String => String}] e.g. {"1" => "eth0", "2" => "eth1"}
+    def _build_nic_groups_to_iface(network_configurator)
+      nic_groups_to_iface = {}
+      network_configurator.nic_groups.each_with_index do |group_networks, nic_index|
+        nic_group = group_networks.first.spec['nic_group']
+        if nic_group
+          nic_groups_to_iface[nic_group] = "eth#{nic_index}"
+        end
+      end
+      nic_groups_to_iface
     end
   end
 end

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_network.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ipaddr'
+
 module Bosh::AzureCloud
   class VMManager
     private
@@ -97,19 +99,28 @@ module Bosh::AzureCloud
           load_balancer = @azure_client.get_load_balancer_by_name(load_balancer_config.resource_group_name, load_balancer_config.name)
           cloud_error("Cannot find the load balancer '#{load_balancer_config.name}'") if load_balancer.nil?
 
+          pools = load_balancer[:backend_address_pools]
+          pools = [pools] unless pools.is_a?(Array)
+
           if load_balancer_config.backend_pool_name
             # NOTE: This is the only place where we simultaneously have both the Bosh LB config (from the vm_type) AND the Azure LB info (from the Azure API).
             # Since the `AzureClient.create_network_interface` method only uses the first backend pool,
             # and since there is not a 1-to-1 mapping between the vm_type LB configs and LBs (despite the config property name, each vm_type LB config actually represents a single LB Backend Pool, not a whole LB),
             # we can therefore remove all pools EXCEPT the specified pool.
             # To handle multiple pools of a single LB, you should use 1 vm_type LB Hash (with LB name + backend_pool_name) per pool.
-            pools = load_balancer[:backend_address_pools]
-            pools = [pools] unless pools.is_a?(Array)
             pool = pools.find { |p| Hash(p)[:name] == load_balancer_config.backend_pool_name }
             cloud_error("'#{load_balancer_config.name}' does not have a backend_pool named '#{load_balancer_config.backend_pool_name}': #{load_balancer}") if pool.nil?
 
             load_balancer[:backend_address_pools] = [pool]
           end
+
+          if load_balancer_config.backend_pool_name_v6
+            pool_v6 = pools.find { |p| Hash(p)[:name] == load_balancer_config.backend_pool_name_v6 }
+            cloud_error("'#{load_balancer_config.name}' does not have a backend_pool named '#{load_balancer_config.backend_pool_name_v6}': #{load_balancer}") if pool_v6.nil?
+
+            load_balancer[:backend_address_pools_v6] = [pool_v6]
+          end
+
           load_balancer
         end
       end
@@ -198,26 +209,40 @@ module Bosh::AzureCloud
       # tasks to create NICs, NICs will be created in different threads
       tasks_creating = []
 
-      networks = network_configurator.networks
-      networks.each_with_index do |network, index|
-        network_security_group = _get_network_security_group(vm_props, network)
-        application_security_groups = _get_application_security_groups(vm_props, network)
-        ip_forwarding = _get_ip_forwarding(vm_props, network)
-        accelerated_networking = _get_accelerated_networking(vm_props, network)
-        nic_name = "#{vm_name}-#{index}"
+      nic_groups = network_configurator.nic_groups
+      nic_groups.each_with_index do |group_networks, nic_index|
+        primary_network = group_networks.first
+
+        network_security_group = _get_network_security_group(vm_props, primary_network)
+        application_security_groups = _get_application_security_groups(vm_props, primary_network)
+        ip_forwarding = _get_ip_forwarding(vm_props, primary_network)
+        accelerated_networking = _get_accelerated_networking(vm_props, primary_network)
+        nic_name = "#{vm_name}-#{nic_index}"
+        subnet = _get_network_subnet(primary_network)
+
+        ip_configurations = group_networks.each_with_index.map do |network, ipconfig_index|
+          ip_version = _detect_ip_version(network)
+          ipconfig = {
+            name: "ipconfig#{nic_index}-#{ipconfig_index}",
+            ip_version: ip_version,
+            subnet: subnet
+          }
+          ipconfig[:private_ip] = network.private_ip if network.respond_to?(:private_ip)
+          ipconfig
+        end
+
         nic_params = {
           name: nic_name,
           location: location,
-          private_ip: network.is_a?(ManualNetwork) ? network.private_ip : nil,
           network_security_group: network_security_group,
           application_security_groups: application_security_groups,
-          ipconfig_name: "ipconfig#{index}",
           enable_ip_forwarding: ip_forwarding,
-          enable_accelerated_networking: accelerated_networking
+          enable_accelerated_networking: accelerated_networking,
+          ip_configurations: ip_configurations
         }
-        nic_params[:subnet] = _get_network_subnet(network)
+
         # NOTE: The first NIC is the Primary/Gateway network. See: `Bosh::AzureCloud::NetworkConfigurator.initialize`.
-        if index.zero?
+        if nic_index.zero?
           nic_params[:public_ip] = public_ip
           nic_params[:tags] = primary_nic_tags
           nic_params[:load_balancers] = load_balancers
@@ -238,6 +263,17 @@ module Bosh::AzureCloud
       # Calling .wait before .value! to make sure that all tasks are completed.
       tasks_creating.map(&:wait)
       tasks_creating.map(&:value!)
+    end
+
+    # Determine whether a network's IP is IPv4 or IPv6
+    def _detect_ip_version(network)
+      has_explicit_ip = network.respond_to?(:private_ip) && network.private_ip && !network.private_ip.empty?
+      return 'IPv4' unless has_explicit_ip
+
+      IPAddr.new(network.private_ip).ipv6? ? 'IPv6' : 'IPv4'
+    rescue IPAddr::InvalidAddressError => e
+      @logger.warn("Invalid IP address '#{network.private_ip}': #{e.message}, defaulting to IPv4")
+      'IPv4'
     end
 
     def _delete_possible_network_interfaces(resource_group_name, vm_name)

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_network.rb
@@ -224,7 +224,10 @@ module Bosh::AzureCloud
         networks_with_ip_versions = group_networks.map do |network|
           [network, _detect_ip_version(network)]
         end
-        networks_with_ip_versions.sort_by! { |_network, ip_version| ip_version == 'IPv4' ? 0 : 1 }
+        ipv4_networks, ipv6_networks = networks_with_ip_versions.partition do |_network, ip_version|
+          ip_version == 'IPv4'
+        end
+        networks_with_ip_versions = ipv4_networks + ipv6_networks
 
         ip_configurations = networks_with_ip_versions.each_with_index.map do |(network, ip_version), ipconfig_index|
           ipconfig = {

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_network.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager_network.rb
@@ -205,6 +205,7 @@ module Bosh::AzureCloud
       public_ip = task_get_or_create_public_ip.value!
       load_balancers = task_get_load_balancers.value!
       application_gateways = task_get_application_gateways.value!
+      public_ip_nic_index = _get_public_ip_nic_index(network_configurator)
 
       # tasks to create NICs, NICs will be created in different threads
       tasks_creating = []
@@ -220,8 +221,12 @@ module Bosh::AzureCloud
         nic_name = "#{vm_name}-#{nic_index}"
         subnet = _get_network_subnet(primary_network)
 
-        ip_configurations = group_networks.each_with_index.map do |network, ipconfig_index|
-          ip_version = _detect_ip_version(network)
+        networks_with_ip_versions = group_networks.map do |network|
+          [network, _detect_ip_version(network)]
+        end
+        networks_with_ip_versions.sort_by! { |_network, ip_version| ip_version == 'IPv4' ? 0 : 1 }
+
+        ip_configurations = networks_with_ip_versions.each_with_index.map do |(network, ip_version), ipconfig_index|
           ipconfig = {
             name: "ipconfig#{nic_index}-#{ipconfig_index}",
             ip_version: ip_version,
@@ -240,15 +245,14 @@ module Bosh::AzureCloud
           enable_accelerated_networking: accelerated_networking,
           ip_configurations: ip_configurations
         }
+        nic_params[:public_ip] = nic_index == public_ip_nic_index ? public_ip : nil
 
         # NOTE: The first NIC is the Primary/Gateway network. See: `Bosh::AzureCloud::NetworkConfigurator.initialize`.
         if nic_index.zero?
-          nic_params[:public_ip] = public_ip
           nic_params[:tags] = primary_nic_tags
           nic_params[:load_balancers] = load_balancers
           nic_params[:application_gateways] = application_gateways
         else
-          nic_params[:public_ip] = nil
           nic_params[:tags] = AZURE_TAGS
           nic_params[:load_balancers] = nil
           nic_params[:application_gateways] = nil
@@ -263,6 +267,19 @@ module Bosh::AzureCloud
       # Calling .wait before .value! to make sure that all tasks are completed.
       tasks_creating.map(&:wait)
       tasks_creating.map(&:value!)
+    end
+
+    def _get_public_ip_nic_index(network_configurator)
+      vip_network = network_configurator.vip_network
+      vip_nic_group = vip_network&.spec&.[]('nic_group')
+      return 0 if vip_nic_group.nil?
+
+      nic_index = network_configurator.nic_groups.index do |group_networks|
+        group_networks.first.nic_group == vip_nic_group
+      end
+      cloud_error("Cannot find nic_group '#{vip_nic_group}' referenced by the vip network") if nic_index.nil?
+
+      nic_index
     end
 
     # Determine whether a network's IP is IPv4 or IPv6

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
@@ -1673,6 +1673,78 @@ describe Bosh::AzureCloud::AzureClient do
     end
   end
 
+  describe '#build_ip_configurations' do
+    let(:subnet) { { id: 'fake-subnet-id' } }
+    let(:nic_params) do
+      {
+        load_balancers: [
+          {
+            backend_address_pools: [{ id: 'fake-lb-v4-id' }],
+            backend_address_pools_v6: [{ id: 'fake-lb-v6-id' }],
+            frontend_ip_configurations: [
+              {
+                public_ip: { public_ip_address_version: 'IPv4' },
+                inbound_nat_rules: [{ id: 'fake-nat-rule-v4-id' }]
+              },
+              {
+                public_ip: { public_ip_address_version: 'IPv6' },
+                inbound_nat_rules: [{ id: 'fake-nat-rule-v6-id' }]
+              }
+            ]
+          }
+        ],
+        application_gateways: [
+          {
+            backend_address_pools: [{ id: 'fake-agw-pool-id' }]
+          }
+        ],
+        ip_configurations: [
+          {
+            name: 'ipconfig0-0',
+            ip_version: 'IPv4',
+            subnet: subnet,
+            private_ip: '10.0.0.5'
+          },
+          {
+            name: 'ipconfig0-1',
+            ip_version: 'IPv4',
+            subnet: subnet,
+            private_ip: '10.0.0.6'
+          },
+          {
+            name: 'ipconfig0-2',
+            ip_version: 'IPv6',
+            subnet: subnet,
+            private_ip: 'fd00::5'
+          }
+        ]
+      }
+    end
+
+    it 'places NAT rules once per family and application gateway pools only on primary IPv4' do
+      ip_configurations = azure_client.send(:build_ip_configurations, nic_params)
+      primary_ipv4 = ip_configurations[0]['properties']
+      secondary_ipv4 = ip_configurations[1]['properties']
+      ipv6 = ip_configurations[2]['properties']
+
+      expect(primary_ipv4).to include(
+        'loadBalancerBackendAddressPools' => [{ 'id' => 'fake-lb-v4-id' }],
+        'loadBalancerInboundNatRules' => [{ id: 'fake-nat-rule-v4-id' }],
+        'applicationGatewayBackendAddressPools' => [{ 'id' => 'fake-agw-pool-id' }]
+      )
+      expect(secondary_ipv4).to include(
+        'loadBalancerBackendAddressPools' => [{ 'id' => 'fake-lb-v4-id' }]
+      )
+      expect(secondary_ipv4).not_to have_key('loadBalancerInboundNatRules')
+      expect(secondary_ipv4).not_to have_key('applicationGatewayBackendAddressPools')
+      expect(ipv6).to include(
+        'loadBalancerBackendAddressPools' => [{ 'id' => 'fake-lb-v6-id' }],
+        'loadBalancerInboundNatRules' => [{ id: 'fake-nat-rule-v6-id' }]
+      )
+      expect(ipv6).not_to have_key('applicationGatewayBackendAddressPools')
+    end
+  end
+
   describe '#parse_network_interface — dual-stack NIC response' do
     let(:dual_stack_nic_response) do
       {

--- a/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/create_network_interface_spec.rb
@@ -1141,4 +1141,632 @@ describe Bosh::AzureCloud::AzureClient do
     end
   end
 
+
+  describe '#create_network_interface (dual-stack)' do
+    let(:nic_name) { 'fake-nic-name' }
+    let(:nsg_id) { 'fake-nsg-id' }
+    let(:subnet) { { id: 'fake-subnet-id' } }
+    let(:network_interface_uri) { "https://management.azure.com/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkInterfaces/#{nic_name}?api-version=#{api_version_network}" }
+
+    before do
+      stub_request(:post, token_uri).to_return(
+        status: 200,
+        body: {
+          'access_token' => valid_access_token,
+          'expires_on' => expires_on
+        }.to_json,
+        headers: {}
+      )
+    end
+
+    def stub_create_nic(expected_request_body)
+      stub_request(:put, network_interface_uri)
+        .with(body: expected_request_body.to_json)
+        .to_return(
+          status: 200,
+          body: '',
+          headers: { 'azure-asyncoperation' => operation_status_link }
+        )
+      stub_request(:get, operation_status_link).to_return(
+        status: 200,
+        body: '{"status":"Succeeded"}',
+        headers: {}
+      )
+    end
+
+    context 'dual-stack NIC with IPv4 + IPv6 ipConfigurations' do
+      let(:nic_params) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: { 'user-agent' => 'bosh' },
+          enable_ip_forwarding: false,
+          enable_accelerated_networking: true,
+          network_security_group: { id: nsg_id },
+          application_security_groups: [{ id: 'fake-asg-id' }],
+          dns_servers: nil,
+          public_ip: { id: 'fake-public-ip-id' },
+          load_balancers: nil,
+          application_gateways: nil,
+          ip_configurations: [
+            {
+              name: 'ipconfig0-0',
+              ip_version: 'IPv4',
+              subnet: subnet,
+              private_ip: '10.0.0.5'
+            },
+            {
+              name: 'ipconfig0-1',
+              ip_version: 'IPv6',
+              subnet: subnet,
+              private_ip: 'fd00::5'
+            }
+          ]
+        }
+      end
+
+      let(:expected_request_body) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: { 'user-agent' => 'bosh' },
+          properties: {
+            networkSecurityGroup: { id: nsg_id },
+            enableIPForwarding: false,
+            enableAcceleratedNetworking: true,
+            ipConfigurations: [
+              {
+                name: 'ipconfig0-0',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv4',
+                  subnet: { id: subnet[:id] },
+                  primary: true,
+                  privateIPAddress: '10.0.0.5',
+                  publicIPAddress: { id: 'fake-public-ip-id' },
+                  applicationSecurityGroups: [{ id: 'fake-asg-id' }]
+                }
+              },
+              {
+                name: 'ipconfig0-1',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv6',
+                  subnet: { id: subnet[:id] },
+                  primary: false,
+                  privateIPAddress: 'fd00::5',
+                  applicationSecurityGroups: [{ id: 'fake-asg-id' }]
+                }
+              }
+            ],
+            dnsSettings: {
+              dnsServers: []
+            }
+          }
+        }
+      end
+
+      before { stub_create_nic(expected_request_body) }
+
+      it 'creates a NIC with a primary IPv4 ipConfiguration carrying the public IP and a secondary IPv6 ipConfiguration, with ASGs attached to both' do
+        # The webmock stub above pins the exact request body, so any drift in
+        # primary flags, public-IP placement, or ASG attachment will fail here.
+        expect { azure_client.create_network_interface(resource_group, nic_params) }.not_to raise_error
+      end
+    end
+
+    context 'dual-stack NIC with load balancer (separate IPv4/IPv6 backend pools)' do
+      let(:nic_params) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: {},
+          enable_ip_forwarding: false,
+          enable_accelerated_networking: false,
+          network_security_group: { id: nsg_id },
+          application_security_groups: [],
+          dns_servers: nil,
+          public_ip: nil,
+          load_balancers: [
+            {
+              backend_address_pools: [
+                { name: 'pool-v4', id: 'fake-lb-pool-v4-id' }
+              ],
+              backend_address_pools_v6: [
+                { name: 'pool-v6', id: 'fake-lb-pool-v6-id' }
+              ],
+              frontend_ip_configurations: [
+                { inbound_nat_rules: [] }
+              ]
+            }
+          ],
+          application_gateways: nil,
+          ip_configurations: [
+            {
+              name: 'ipconfig0-0',
+              ip_version: 'IPv4',
+              subnet: subnet,
+              private_ip: '10.0.0.5'
+            },
+            {
+              name: 'ipconfig0-1',
+              ip_version: 'IPv6',
+              subnet: subnet,
+              private_ip: 'fd00::5'
+            }
+          ]
+        }
+      end
+
+      let(:expected_request_body) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: {},
+          properties: {
+            networkSecurityGroup: { id: nsg_id },
+            enableIPForwarding: false,
+            enableAcceleratedNetworking: false,
+            ipConfigurations: [
+              {
+                name: 'ipconfig0-0',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv4',
+                  subnet: { id: subnet[:id] },
+                  primary: true,
+                  privateIPAddress: '10.0.0.5',
+                  loadBalancerBackendAddressPools: [{ id: 'fake-lb-pool-v4-id' }]
+                }
+              },
+              {
+                name: 'ipconfig0-1',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv6',
+                  subnet: { id: subnet[:id] },
+                  primary: false,
+                  privateIPAddress: 'fd00::5',
+                  loadBalancerBackendAddressPools: [{ id: 'fake-lb-pool-v6-id' }]
+                }
+              }
+            ],
+            dnsSettings: {
+              dnsServers: []
+            }
+          }
+        }
+      end
+
+      before { stub_create_nic(expected_request_body) }
+
+      it 'routes each ipConfig to the matching IP-family backend pool' do
+        expect { azure_client.create_network_interface(resource_group, nic_params) }.not_to raise_error
+      end
+    end
+
+    context 'dual-stack NIC with application gateway (IPv4-only backend)' do
+      let(:nic_params) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: {},
+          enable_ip_forwarding: false,
+          enable_accelerated_networking: false,
+          network_security_group: nil,
+          application_security_groups: [],
+          dns_servers: nil,
+          public_ip: nil,
+          load_balancers: nil,
+          application_gateways: [
+            {
+              backend_address_pools: [
+                { name: 'agw-pool', id: 'fake-agw-pool-id' }
+              ]
+            }
+          ],
+          ip_configurations: [
+            {
+              name: 'ipconfig0-0',
+              ip_version: 'IPv4',
+              subnet: subnet,
+              private_ip: '10.0.0.5'
+            },
+            {
+              name: 'ipconfig0-1',
+              ip_version: 'IPv6',
+              subnet: subnet,
+              private_ip: 'fd00::5'
+            }
+          ]
+        }
+      end
+
+      let(:expected_request_body) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: {},
+          properties: {
+            networkSecurityGroup: nil,
+            enableIPForwarding: false,
+            enableAcceleratedNetworking: false,
+            ipConfigurations: [
+              {
+                name: 'ipconfig0-0',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv4',
+                  subnet: { id: subnet[:id] },
+                  primary: true,
+                  privateIPAddress: '10.0.0.5',
+                  applicationGatewayBackendAddressPools: [{ id: 'fake-agw-pool-id' }]
+                }
+              },
+              {
+                name: 'ipconfig0-1',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv6',
+                  subnet: { id: subnet[:id] },
+                  primary: false,
+                  privateIPAddress: 'fd00::5'
+                }
+              }
+            ],
+            dnsSettings: {
+              dnsServers: []
+            }
+          }
+        }
+      end
+
+      before { stub_create_nic(expected_request_body) }
+
+      it 'should attach AGW backend pool only to IPv4 ipConfiguration, not IPv6' do
+        expect { azure_client.create_network_interface(resource_group, nic_params) }.not_to raise_error
+      end
+    end
+
+    context 'dual-stack NIC with dynamic IPv6 allocation (no private_ip)' do
+      let(:nic_params) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: {},
+          enable_ip_forwarding: false,
+          enable_accelerated_networking: false,
+          network_security_group: nil,
+          application_security_groups: [],
+          dns_servers: nil,
+          public_ip: nil,
+          load_balancers: nil,
+          application_gateways: nil,
+          ip_configurations: [
+            {
+              name: 'ipconfig0-0',
+              ip_version: 'IPv4',
+              subnet: subnet,
+              private_ip: '10.0.0.5'
+            },
+            {
+              name: 'ipconfig0-1',
+              ip_version: 'IPv6',
+              subnet: subnet,
+              private_ip: nil
+            }
+          ]
+        }
+      end
+
+      let(:expected_request_body) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: {},
+          properties: {
+            networkSecurityGroup: nil,
+            enableIPForwarding: false,
+            enableAcceleratedNetworking: false,
+            ipConfigurations: [
+              {
+                name: 'ipconfig0-0',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv4',
+                  subnet: { id: subnet[:id] },
+                  primary: true,
+                  privateIPAddress: '10.0.0.5'
+                }
+              },
+              {
+                name: 'ipconfig0-1',
+                properties: {
+                  privateIPAllocationMethod: 'Dynamic',
+                  privateIPAddressVersion: 'IPv6',
+                  subnet: { id: subnet[:id] },
+                  primary: false
+                }
+              }
+            ],
+            dnsSettings: {
+              dnsServers: []
+            }
+          }
+        }
+      end
+
+      before { stub_create_nic(expected_request_body) }
+
+      it 'should use Dynamic allocation for IPv6 when no private_ip is specified' do
+        expect { azure_client.create_network_interface(resource_group, nic_params) }.not_to raise_error
+      end
+    end
+
+    context 'backward compatibility — single IPv4 ipConfiguration via ip_configurations array' do
+      let(:nic_params) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: {},
+          enable_ip_forwarding: false,
+          enable_accelerated_networking: false,
+          network_security_group: nil,
+          application_security_groups: [],
+          dns_servers: nil,
+          public_ip: nil,
+          load_balancers: nil,
+          application_gateways: nil,
+          ip_configurations: [
+            {
+              name: 'ipconfig0-0',
+              ip_version: 'IPv4',
+              subnet: subnet,
+              private_ip: '10.0.0.100'
+            }
+          ]
+        }
+      end
+
+      let(:expected_request_body) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: {},
+          properties: {
+            networkSecurityGroup: nil,
+            enableIPForwarding: false,
+            enableAcceleratedNetworking: false,
+            ipConfigurations: [
+              {
+                name: 'ipconfig0-0',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv4',
+                  subnet: { id: subnet[:id] },
+                  primary: true,
+                  privateIPAddress: '10.0.0.100'
+                }
+              }
+            ],
+            dnsSettings: {
+              dnsServers: []
+            }
+          }
+        }
+      end
+
+      before { stub_create_nic(expected_request_body) }
+
+      it 'should produce identical payload to legacy single-ipconfig path' do
+        expect { azure_client.create_network_interface(resource_group, nic_params) }.not_to raise_error
+      end
+    end
+
+    context 'dual-stack + LB + AGW + ASG combined' do
+      let(:nic_params) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: { 'user-agent' => 'bosh' },
+          enable_ip_forwarding: true,
+          enable_accelerated_networking: true,
+          network_security_group: { id: nsg_id },
+          application_security_groups: [{ id: 'fake-asg-1' }, { id: 'fake-asg-2' }],
+          dns_servers: ['168.63.129.16'],
+          public_ip: { id: 'fake-public-ip-id' },
+          load_balancers: [
+            {
+              backend_address_pools: [
+                { name: 'pool-v4', id: 'fake-lb-v4-id' }
+              ],
+              backend_address_pools_v6: [
+                { name: 'pool-v6', id: 'fake-lb-v6-id' }
+              ],
+              frontend_ip_configurations: [
+                {
+                  public_ip: { public_ip_address_version: 'IPv6' },
+                  inbound_nat_rules: [{ id: 'fake-nat-rule-v6-id' }]
+                },
+                {
+                  public_ip: { public_ip_address_version: 'IPv4' },
+                  inbound_nat_rules: [{ id: 'fake-nat-rule-v4-id' }]
+                }
+              ]
+            }
+          ],
+          application_gateways: [
+            {
+              backend_address_pools: [
+                { name: 'agw-pool', id: 'fake-agw-pool-id' }
+              ]
+            }
+          ],
+          ip_configurations: [
+            {
+              name: 'ipconfig0-0',
+              ip_version: 'IPv4',
+              subnet: subnet,
+              private_ip: '10.0.0.5'
+            },
+            {
+              name: 'ipconfig0-1',
+              ip_version: 'IPv6',
+              subnet: subnet,
+              private_ip: 'fd00::5'
+            }
+          ]
+        }
+      end
+
+      let(:expected_request_body) do
+        {
+          name: nic_name,
+          location: 'westeurope',
+          tags: { 'user-agent' => 'bosh' },
+          properties: {
+            networkSecurityGroup: { id: nsg_id },
+            enableIPForwarding: true,
+            enableAcceleratedNetworking: true,
+            ipConfigurations: [
+              {
+                name: 'ipconfig0-0',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv4',
+                  subnet: { id: subnet[:id] },
+                  primary: true,
+                  privateIPAddress: '10.0.0.5',
+                  publicIPAddress: { id: 'fake-public-ip-id' },
+                  loadBalancerBackendAddressPools: [{ id: 'fake-lb-v4-id' }],
+                  loadBalancerInboundNatRules: [{ id: 'fake-nat-rule-v4-id' }],
+                  applicationGatewayBackendAddressPools: [{ id: 'fake-agw-pool-id' }],
+                  applicationSecurityGroups: [{ id: 'fake-asg-1' }, { id: 'fake-asg-2' }]
+                }
+              },
+              {
+                name: 'ipconfig0-1',
+                properties: {
+                  privateIPAllocationMethod: 'Static',
+                  privateIPAddressVersion: 'IPv6',
+                  subnet: { id: subnet[:id] },
+                  primary: false,
+                  privateIPAddress: 'fd00::5',
+                  loadBalancerBackendAddressPools: [{ id: 'fake-lb-v6-id' }],
+                  loadBalancerInboundNatRules: [{ id: 'fake-nat-rule-v6-id' }],
+                  applicationSecurityGroups: [{ id: 'fake-asg-1' }, { id: 'fake-asg-2' }]
+                }
+              }
+            ],
+            dnsSettings: {
+              dnsServers: ['168.63.129.16']
+            }
+          }
+        }
+      end
+
+      before { stub_create_nic(expected_request_body) }
+
+      it 'distributes LB pools, NAT rules, AGW, ASGs, and public IP by IP family' do
+        expect { azure_client.create_network_interface(resource_group, nic_params) }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#parse_network_interface — dual-stack NIC response' do
+    let(:dual_stack_nic_response) do
+      {
+        'id' => '/subscriptions/fake-sub/resourceGroups/fake-rg/providers/Microsoft.Network/networkInterfaces/vm-abc-0',
+        'name' => 'vm-abc-0',
+        'location' => 'westeurope',
+        'tags' => { 'user-agent' => 'bosh' },
+        'properties' => {
+          'provisioningState' => 'Succeeded',
+          'enableIPForwarding' => false,
+          'enableAcceleratedNetworking' => true,
+          'dnsSettings' => { 'dnsServers' => [] },
+          'ipConfigurations' => [
+            {
+              'id' => '/subscriptions/fake-sub/.../ipconfig0-0',
+              'name' => 'ipconfig0-0',
+              'properties' => {
+                'primary' => true,
+                'privateIPAddress' => '10.0.0.5',
+                'privateIPAllocationMethod' => 'Static',
+                'privateIPAddressVersion' => 'IPv4',
+                'subnet' => { 'id' => 'fake-subnet-id' },
+                'publicIPAddress' => { 'id' => 'fake-public-ip-id' },
+                'loadBalancerBackendAddressPools' => [
+                  { 'id' => '/subscriptions/fake-sub/.../backendAddressPools/pool-v4' }
+                ],
+                'applicationGatewayBackendAddressPools' => [
+                  { 'id' => '/subscriptions/fake-sub/.../backendAddressPools/agw-pool' }
+                ],
+                'applicationSecurityGroups' => [
+                  { 'id' => 'fake-asg-id' }
+                ]
+              }
+            },
+            {
+              'id' => '/subscriptions/fake-sub/.../ipconfig0-1',
+              'name' => 'ipconfig0-1',
+              'properties' => {
+                'primary' => false,
+                'privateIPAddress' => 'fd00::5',
+                'privateIPAllocationMethod' => 'Static',
+                'privateIPAddressVersion' => 'IPv6',
+                'subnet' => { 'id' => 'fake-subnet-id' },
+                'loadBalancerBackendAddressPools' => [
+                  { 'id' => '/subscriptions/fake-sub/.../backendAddressPools/pool-v6' }
+                ],
+                'applicationSecurityGroups' => [
+                  { 'id' => 'fake-asg-id' }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    end
+
+    subject(:result) { azure_client.send(:parse_network_interface, dual_stack_nic_response, recursive: false) }
+    let(:ipv4_config) { result[:ip_configurations].find { |c| c[:primary] } }
+    let(:ipv6_config) { result[:ip_configurations].find { |c| !c[:primary] } }
+
+    it 'parses both ipConfigurations with the correct IP family, primary flag, and address' do
+      expect(result[:ip_configurations].length).to eq(2)
+
+      expect(ipv4_config).to include(
+        name: 'ipconfig0-0',
+        private_ip: '10.0.0.5',
+        private_ip_address_version: 'IPv4'
+      )
+      expect(ipv6_config).to include(
+        name: 'ipconfig0-1',
+        private_ip: 'fd00::5',
+        private_ip_address_version: 'IPv6'
+      )
+    end
+
+    it 'distributes public IP, LB pools, AGW pools, and ASGs across the matching ipConfigs' do
+      # Public IP and AGW are IPv4-only; LB has per-family pools; ASGs apply to both.
+      expect(ipv4_config[:public_ip]).to eq(id: 'fake-public-ip-id')
+      expect(ipv6_config[:public_ip]).to be_nil
+
+      expect(ipv4_config[:load_balancers].map { |lb| lb[:id] }).to all(include('pool-v4'))
+      expect(ipv6_config[:load_balancers].map { |lb| lb[:id] }).to all(include('pool-v6'))
+
+      expect(ipv4_config[:application_gateways].length).to eq(1)
+      expect(ipv6_config[:application_gateways]).to be_nil
+
+      [ipv4_config, ipv6_config].each do |config|
+        expect(config[:application_security_groups]).to eq([{ id: 'fake-asg-id' }])
+      end
+    end
+
+    it 'exposes backward-compatible top-level accessors from the primary (IPv4) config' do
+      expect(result[:private_ip]).to eq('10.0.0.5')
+      expect(result[:public_ip]).to eq(id: 'fake-public-ip-id')
+    end
+  end
 end

--- a/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/get_operation_spec.rb
@@ -125,6 +125,7 @@ describe Bosh::AzureCloud::AzureClient do
           'properties' => {
             'provisioningState' => 'fake-state',
             'privateIPAllocationMethod' => 'bar',
+            'privateIPAddressVersion' => 'IPv4',
             'publicIPAddress' => {
               'id' => public_ip_id
             },
@@ -155,6 +156,7 @@ describe Bosh::AzureCloud::AzureClient do
           name: 'fake-name',
           provisioning_state: 'fake-state',
           private_ip_allocation_method: 'bar',
+          private_ip_address_version: 'IPv4',
           public_ip: fake_public_ip,
           inbound_nat_rules: []
         }

--- a/src/bosh_azure_cpi/spec/unit/manual_network_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/manual_network_spec.rb
@@ -168,6 +168,23 @@ describe Bosh::AzureCloud::ManualNetwork do
     end
   end
 
+  context 'when ip is IPv6' do
+    let(:network_spec) do
+      {
+        'ip' => 'fd00::5',
+        'cloud_properties' => {
+          'virtual_network_name' => 'foo',
+          'subnet_name' => 'bar'
+        }
+      }
+    end
+
+    it 'uses the IPv6 address as the private IP' do
+      network = Bosh::AzureCloud::ManualNetwork.new(azure_config, 'default', network_spec)
+      expect(network.private_ip).to eq('fd00::5')
+    end
+  end
+
   context 'when optional cloud properties are not specified' do
     let(:network_spec) do
       {

--- a/src/bosh_azure_cpi/spec/unit/models/load_balancer_config_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/models/load_balancer_config_spec.rb
@@ -8,10 +8,14 @@ describe Bosh::AzureCloud::LoadBalancerConfig do
       let(:name) { 'fake_name' }
       let(:resource_group_name) { 'fake_rg' }
       let(:backend_pool_name) { 'fake_pool' }
-      let(:expected_string) { "name: #{name}, resource_group_name: #{resource_group_name}, backend_pool_name: #{backend_pool_name}" }
-      let(:load_balancer_config) { Bosh::AzureCloud::LoadBalancerConfig.new(resource_group_name, name, backend_pool_name) }
+      let(:backend_pool_name_v6) { 'fake_pool_v6' }
+      let(:expected_string) { "name: #{name}, resource_group_name: #{resource_group_name}, backend_pool_name: #{backend_pool_name}, backend_pool_name_v6: #{backend_pool_name_v6}" }
+      let(:load_balancer_config) do
+        Bosh::AzureCloud::LoadBalancerConfig.new(resource_group_name, name, backend_pool_name, backend_pool_name_v6)
+      end
 
-      it 'should return the correct string' do
+      it 'returns the configured IPv6 pool name in its reader and string representation' do
+        expect(load_balancer_config.backend_pool_name_v6).to eq(backend_pool_name_v6)
         expect(load_balancer_config.to_s).to eq(expected_string)
       end
     end

--- a/src/bosh_azure_cpi/spec/unit/models/vm_cloud_props_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/models/vm_cloud_props_spec.rb
@@ -150,6 +150,8 @@ describe Bosh::AzureCloud::VMCloudProps do
     context 'when load_balancer is a hash' do
       let(:lb_name) { 'fake_lb_name' }
       let(:resource_group_name) { 'fake_resource_group' }
+      let(:backend_pool_name) { 'fake_backend_pool' }
+      let(:backend_pool_name_v6) { 'fake_backend_pool_v6' }
 
       context 'when resource group not empty' do
         let(:vm_cloud_props) do
@@ -158,7 +160,9 @@ describe Bosh::AzureCloud::VMCloudProps do
               'instance_type' => 'Standard_D1',
               'load_balancer' => {
                 'name' => lb_name,
-                'resource_group_name' => resource_group_name
+                'resource_group_name' => resource_group_name,
+                'backend_pool_name' => backend_pool_name,
+                'backend_pool_name_v6' => backend_pool_name_v6
               }
             }, azure_config_managed
           )
@@ -169,6 +173,8 @@ describe Bosh::AzureCloud::VMCloudProps do
           load_balancer = vm_cloud_props.load_balancers.first
           expect(load_balancer.name).to eq(lb_name)
           expect(load_balancer.resource_group_name).to eq(resource_group_name)
+          expect(load_balancer.backend_pool_name).to eq(backend_pool_name)
+          expect(load_balancer.backend_pool_name_v6).to eq(backend_pool_name_v6)
         end
       end
 

--- a/src/bosh_azure_cpi/spec/unit/network_configurator_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/network_configurator_spec.rb
@@ -173,4 +173,204 @@ describe Bosh::AzureCloud::NetworkConfigurator do
       end
     end
   end
+
+  describe '#nic_groups' do
+    context 'when no nic_group is specified (backward compatibility)' do
+      let(:network_spec) do
+        {
+          'network1' => {
+            'type' => 'manual',
+            'ip' => '10.0.0.5',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar'
+            }
+          }
+        }
+      end
+
+      it 'should create one nic_group per network (each network = its own NIC)' do
+        nc = Bosh::AzureCloud::NetworkConfigurator.new(azure_config, network_spec)
+        expect(nc.nic_groups.length).to eq(1)
+        expect(nc.nic_groups[0].length).to eq(1)
+        expect(nc.nic_groups[0][0].nic_group).to eq('network1')
+      end
+    end
+
+    context 'when two networks have no nic_group (backward compatibility with multiple NICs)' do
+      let(:network_spec) do
+        {
+          'network1' => {
+            'type' => 'manual',
+            'default' => %w[dns gateway],
+            'ip' => '10.0.0.5',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar'
+            }
+          },
+          'network2' => {
+            'type' => 'manual',
+            'default' => %w[dns gateway],
+            'ip' => '10.1.0.5',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'baz'
+            }
+          }
+        }
+      end
+
+      it 'creates one nic_group per network and puts the primary network group first' do
+        nc = Bosh::AzureCloud::NetworkConfigurator.new(azure_config, network_spec)
+        expect(nc.nic_groups.map(&:length)).to eq([1, 1])
+        expect(nc.nic_groups[0][0].nic_group).to eq('network2')
+      end
+    end
+
+    context 'when two networks share the same nic_group (dual-stack)' do
+      let(:network_spec) do
+        {
+          'ipv4' => {
+            'type' => 'manual',
+            'default' => %w[dns gateway],
+            'ip' => '10.0.0.5',
+            'nic_group' => '1',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar'
+            }
+          },
+          'ipv6' => {
+            'type' => 'manual',
+            'ip' => 'fd00::5',
+            'nic_group' => '1',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar'
+            }
+          }
+        }
+      end
+
+      it 'groups both networks into a single NIC group' do
+        nc = Bosh::AzureCloud::NetworkConfigurator.new(azure_config, network_spec)
+        expect(nc.nic_groups.length).to eq(1)
+        expect(nc.nic_groups[0].map(&:private_ip)).to contain_exactly('10.0.0.5', 'fd00::5')
+      end
+    end
+
+    context 'when networks in the same nic_group reference different Azure subnets' do
+      let(:network_spec) do
+        {
+          'ipv4' => {
+            'type' => 'manual',
+            'default' => %w[dns gateway],
+            'ip' => '10.0.0.5',
+            'nic_group' => '1',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar'
+            }
+          },
+          'ipv6' => {
+            'type' => 'manual',
+            'ip' => 'fd00::5',
+            'nic_group' => '1',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar-v6'
+            }
+          }
+        }
+      end
+
+      it 'rejects the group instead of silently using the first subnet' do
+        expect do
+          Bosh::AzureCloud::NetworkConfigurator.new(azure_config, network_spec)
+        end.to raise_error(
+          Bosh::Clouds::CloudError,
+          /Networks in nic_group '1' must use the same Azure subnet/
+        )
+      end
+    end
+
+    context 'when networks are split across multiple nic_groups (multi-NIC dual-stack)' do
+      let(:network_spec) do
+        {
+          'nic1-v4' => {
+            'type' => 'manual',
+            'default' => %w[dns gateway],
+            'ip' => '10.0.0.5',
+            'nic_group' => '1',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar'
+            }
+          },
+          'nic1-v6' => {
+            'type' => 'manual',
+            'ip' => 'fd00::5',
+            'nic_group' => '1',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar'
+            }
+          },
+          'nic2-v4' => {
+            'type' => 'manual',
+            'ip' => '10.1.0.5',
+            'nic_group' => '2',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'baz'
+            }
+          }
+        }
+      end
+
+      it 'creates two nic_groups, primary first, grouping networks sharing nic_group together' do
+        nc = Bosh::AzureCloud::NetworkConfigurator.new(azure_config, network_spec)
+        expect(nc.nic_groups.length).to eq(2)
+        expect(nc.nic_groups[0].map(&:private_ip)).to contain_exactly('10.0.0.5', 'fd00::5')
+        expect(nc.nic_groups[1].map(&:private_ip)).to contain_exactly('10.1.0.5')
+      end
+    end
+
+    context 'when vip network is present alongside nic_groups' do
+      let(:network_spec) do
+        {
+          'default' => {
+            'type' => 'manual',
+            'default' => %w[dns gateway],
+            'ip' => '10.0.0.5',
+            'nic_group' => '1',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar'
+            }
+          },
+          'v6' => {
+            'type' => 'manual',
+            'ip' => 'fd00::5',
+            'nic_group' => '1',
+            'cloud_properties' => {
+              'virtual_network_name' => 'foo',
+              'subnet_name' => 'bar'
+            }
+          },
+          'public' => {
+            'type' => 'vip'
+          }
+        }
+      end
+
+      it 'excludes the vip network and still groups the remaining networks correctly' do
+        nc = Bosh::AzureCloud::NetworkConfigurator.new(azure_config, network_spec)
+        expect(nc.nic_groups.length).to eq(1)
+        expect(nc.nic_groups[0].length).to eq(2)
+        expect(nc.nic_groups.flatten).to all(be_a(Bosh::AzureCloud::ManualNetwork))
+      end
+    end
+  end
 end

--- a/src/bosh_azure_cpi/spec/unit/network_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/network_spec.rb
@@ -77,4 +77,41 @@ describe Bosh::AzureCloud::Network do
       expect(network.spec).to eq(network_spec)
     end
   end
+
+  describe '#nic_group' do
+    context 'when nic_group is specified in the network spec' do
+      let(:network_spec) do
+        {
+          'ip' => '10.0.0.5',
+          'nic_group' => '1',
+          'cloud_properties' => {
+            'virtual_network_name' => 'foo',
+            'subnet_name' => 'bar'
+          }
+        }
+      end
+
+      it 'should return the nic_group from the spec' do
+        network = Bosh::AzureCloud::Network.new(azure_config, 'my-network', network_spec)
+        expect(network.nic_group).to eq('1')
+      end
+    end
+
+    context 'when nic_group is not specified in the network spec' do
+      let(:network_spec) do
+        {
+          'ip' => '10.0.0.5',
+          'cloud_properties' => {
+            'virtual_network_name' => 'foo',
+            'subnet_name' => 'bar'
+          }
+        }
+      end
+
+      it 'should default to the network name' do
+        network = Bosh::AzureCloud::Network.new(azure_config, 'my-network', network_spec)
+        expect(network.nic_group).to eq('my-network')
+      end
+    end
+  end
 end

--- a/src/bosh_azure_cpi/spec/unit/utils/bosh_agent_util_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/utils/bosh_agent_util_spec.rb
@@ -77,4 +77,104 @@ describe Bosh::AzureCloud::BoshAgentUtil do
       expect(user_data).to eq(expected_user_data)
     end
   end
+
+  describe '#user_data_obj — nic_group alias threading' do
+    def networks_for(spec, nic_groups_to_iface = nil)
+      args = [instance_id, dns, agent_id, spec, environment, vm_params, config]
+      args.push(nil, nic_groups_to_iface) unless nic_groups_to_iface.nil?
+      agent_util.user_data_obj(*args)['networks']
+    end
+
+    context 'when networks share a single nic_group (dual-stack)' do
+      let(:dual_stack_spec) do
+        {
+          'default-ipv4' => {
+            'type' => 'manual', 'ip' => '10.0.0.5', 'nic_group' => '1',
+            'default' => %w[dns gateway],
+            'cloud_properties' => { 'virtual_network_name' => 'boshvnet', 'subnet_name' => 'dual-stack-subnet' }
+          },
+          'default-ipv6' => {
+            'type' => 'manual', 'ip' => 'fd00::5', 'nic_group' => '1',
+            'cloud_properties' => { 'virtual_network_name' => 'boshvnet', 'subnet_name' => 'dual-stack-subnet' }
+          }
+        }
+      end
+
+      it 'sets the same alias on both networks, enables use_dhcp, and preserves other fields' do
+        networks = networks_for(dual_stack_spec, '1' => 'eth0')
+
+        expect(networks['default-ipv4']).to include('alias' => 'eth0', 'use_dhcp' => true, 'ip' => '10.0.0.5', 'type' => 'manual')
+        expect(networks['default-ipv6']).to include('alias' => 'eth0', 'use_dhcp' => true, 'ip' => 'fd00::5')
+      end
+
+      it 'does not add derived agent settings to the caller-owned network spec' do
+        networks_for(dual_stack_spec, '1' => 'eth0')
+
+        dual_stack_spec.each_value do |settings|
+          expect(settings).not_to have_key('use_dhcp')
+          expect(settings).not_to have_key('alias')
+        end
+      end
+
+      it 'does not retain aliases across calls that reuse the same network spec' do
+        with_alias = networks_for(dual_stack_spec, '1' => 'eth0')
+        without_alias = networks_for(dual_stack_spec)
+
+        expect(with_alias.values).to all(include('alias' => 'eth0'))
+        without_alias.each_value do |settings|
+          expect(settings).not_to have_key('alias')
+        end
+      end
+    end
+
+    context 'when networks are split across multiple nic_groups (multi-NIC dual-stack)' do
+      let(:multi_nic_spec) do
+        {
+          'net-v4-a' => { 'type' => 'manual', 'ip' => '10.0.0.5', 'nic_group' => '1', 'default' => %w[dns gateway], 'cloud_properties' => {} },
+          'net-v6-a' => { 'type' => 'manual', 'ip' => 'fd00::5',  'nic_group' => '1', 'cloud_properties' => {} },
+          'net-v4-b' => { 'type' => 'manual', 'ip' => '10.0.1.5', 'nic_group' => '2', 'cloud_properties' => {} },
+          'net-v6-b' => { 'type' => 'manual', 'ip' => 'fd01::5',  'nic_group' => '2', 'cloud_properties' => {} }
+        }
+      end
+
+      it 'maps each group to its assigned interface' do
+        networks = networks_for(multi_nic_spec, '1' => 'eth0', '2' => 'eth1')
+        aliases = networks.transform_values { |n| n['alias'] }
+
+        expect(aliases).to eq(
+          'net-v4-a' => 'eth0', 'net-v6-a' => 'eth0',
+          'net-v4-b' => 'eth1', 'net-v6-b' => 'eth1'
+        )
+      end
+    end
+
+    context 'when only some networks have a nic_group' do
+      let(:mixed_spec) do
+        {
+          'grouped-v4' => { 'type' => 'manual',  'ip' => '10.0.0.5', 'nic_group' => '1', 'cloud_properties' => {} },
+          'grouped-v6' => { 'type' => 'manual',  'ip' => 'fd00::5',  'nic_group' => '1', 'cloud_properties' => {} },
+          'ungrouped'  => { 'type' => 'dynamic', 'cloud_properties' => {} }
+        }
+      end
+
+      it 'sets alias only on the grouped networks' do
+        networks = networks_for(mixed_spec, '1' => 'eth0')
+
+        expect(networks['grouped-v4']['alias']).to eq('eth0')
+        expect(networks['grouped-v6']['alias']).to eq('eth0')
+        expect(networks['ungrouped']).not_to have_key('alias')
+      end
+    end
+
+    context 'backward compatibility: no nic_groups_to_iface' do
+      it 'omits alias whether the argument is empty or absent, while still setting use_dhcp' do
+        from_empty   = networks_for(network_spec, {})
+        from_default = networks_for(network_spec)
+
+        expect(from_empty['network_a']).not_to have_key('alias')
+        expect(from_default['network_a']).not_to have_key('alias')
+        expect(from_default['network_a']['use_dhcp']).to be true
+      end
+    end
+  end
 end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/application_security_group_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/application_security_group_spec.rb
@@ -607,7 +607,7 @@ describe Bosh::AzureCloud::VMManager do
               .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
                                                 name: "#{vm_name}-0",
                                                 public_ip: dynamic_public_ip,
-                                                subnet: subnet,
+                                                ip_configurations: [hash_including(subnet: subnet)],
                                                 tags: tags,
                                                 load_balancers: [load_balancer],
                                                 application_gateways: [application_gateway]
@@ -634,7 +634,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(azure_client).to receive(:create_network_interface)
               .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
                                                 public_ip: dynamic_public_ip,
-                                                subnet: subnet,
+                                                ip_configurations: [hash_including(subnet: subnet)],
                                                 tags: tags,
                                                 load_balancers: [load_balancer],
                                                 application_gateways: [application_gateway]

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dual_stack_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dual_stack_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'unit/vm_manager/create/shared_stuff'
+
+describe Bosh::AzureCloud::VMManager, 'dual-stack NIC creation' do
+  include_context 'shared stuff for vm manager'
+
+  subject(:vm_manager_ds) { vm_manager2 }
+
+  let(:dual_stack_subnet) { double('dual-stack-subnet', id: 'fake-dual-stack-subnet-id') }
+
+  let(:manual_network_v4) { build_manual_network(private_ip: '10.0.0.5', subnet_name: 'dual-stack-subnet') }
+  let(:manual_network_v6) { build_manual_network(private_ip: 'fd00::5',  subnet_name: 'dual-stack-subnet') }
+  let(:dynamic_net) do
+    instance_double(Bosh::AzureCloud::DynamicNetwork).tap do |n|
+      allow(n).to receive(:resource_group_name).and_return(MOCK_RESOURCE_GROUP_NAME)
+      allow(n).to receive(:virtual_network_name).and_return('fake-virtual-network-name')
+      allow(n).to receive(:subnet_name).and_return('fake-subnet-name')
+      allow(n).to receive(:security_group).and_return(empty_security_group)
+      allow(n).to receive(:application_security_groups).and_return([])
+      allow(n).to receive(:ip_forwarding).and_return(false)
+      allow(n).to receive(:accelerated_networking).and_return(false)
+      allow(n).to receive(:nic_group).and_return('2')
+    end
+  end
+
+  def build_manual_network(private_ip:, subnet_name:, nic_group: '1')
+    instance_double(Bosh::AzureCloud::ManualNetwork).tap do |n|
+      allow(n).to receive(:resource_group_name).and_return(MOCK_RESOURCE_GROUP_NAME)
+      allow(n).to receive(:virtual_network_name).and_return('fake-virtual-network-name')
+      allow(n).to receive(:subnet_name).and_return(subnet_name)
+      allow(n).to receive(:private_ip).and_return(private_ip)
+      allow(n).to receive(:security_group).and_return(empty_security_group)
+      allow(n).to receive(:application_security_groups).and_return([])
+      allow(n).to receive(:ip_forwarding).and_return(false)
+      allow(n).to receive(:accelerated_networking).and_return(false)
+      allow(n).to receive(:nic_group).and_return(nic_group)
+    end
+  end
+
+  def capture_nic_params
+    captured = []
+    allow(azure_client).to receive(:create_network_interface) { |_rg, params| captured << params }
+    vm_manager_ds.send(:_create_network_interfaces,
+                       MOCK_RESOURCE_GROUP_NAME, vm_name, location,
+                       vm_props, network_configurator)
+    captured.sort_by { |params| params[:name] }
+  end
+
+  before do
+    allow(azure_client).to receive(:get_network_subnet_by_name)
+      .with(MOCK_RESOURCE_GROUP_NAME, 'fake-virtual-network-name', 'dual-stack-subnet')
+      .and_return(dual_stack_subnet)
+    allow(azure_client).to receive(:get_network_subnet_by_name)
+      .with(MOCK_RESOURCE_GROUP_NAME, 'fake-virtual-network-name', 'fake-subnet-name')
+      .and_return(subnet)
+
+    allow(network_configurator).to receive(:vip_network).and_return(nil)
+    allow(azure_client).to receive(:list_public_ips).and_return([])
+    allow(azure_client).to receive(:get_network_interface_by_name)
+  end
+
+  context 'when a single nic_group bundles an IPv4 and an IPv6 manual network' do
+    before do
+      allow(network_configurator).to receive(:nic_groups)
+        .and_return([[manual_network_v6, manual_network_v4]])
+    end
+
+    it 'creates the IPv4 ipConfiguration first regardless of network order' do
+      nic_params_list = capture_nic_params
+
+      expect(nic_params_list.length).to eq(1)
+
+      nic = nic_params_list.first
+      expect(nic[:name]).to eq("#{vm_name}-0")
+      expect(nic[:ip_configurations]).to match([
+        a_hash_including(name: 'ipconfig0-0', ip_version: 'IPv4', private_ip: '10.0.0.5', subnet: dual_stack_subnet),
+        a_hash_including(name: 'ipconfig0-1', ip_version: 'IPv6', private_ip: 'fd00::5',  subnet: dual_stack_subnet)
+      ])
+    end
+  end
+
+  context 'when there are multiple nic_groups and the first one is dual-stack' do
+    before do
+      allow(network_configurator).to receive(:nic_groups)
+        .and_return([[manual_network_v4, manual_network_v6], [dynamic_net]])
+    end
+
+    it 'creates one NIC per group, dual-stacks the first, and only attaches LB/AGW to the primary NIC' do
+      nic_params_list = capture_nic_params
+
+      expect(nic_params_list.map { |p| p[:name] }).to eq(["#{vm_name}-0", "#{vm_name}-1"])
+      expect(nic_params_list[0][:ip_configurations].length).to eq(2)
+      expect(nic_params_list[1][:ip_configurations].length).to eq(1)
+
+      expect(nic_params_list[0][:load_balancers]).to eq([load_balancer])
+      expect(nic_params_list[0][:application_gateways]).to eq([application_gateway])
+      expect(nic_params_list[1][:load_balancers]).to be_nil
+      expect(nic_params_list[1][:application_gateways]).to be_nil
+    end
+  end
+
+  context 'single-stack IPv4 (regression): one network per nic_group' do
+    before do
+      allow(network_configurator).to receive(:nic_groups)
+        .and_return([[manual_network_v4], [dynamic_net]])
+    end
+
+    it 'creates one NIC per network, each with a single IPv4 ipConfiguration' do
+      nic_params_list = capture_nic_params
+
+      expect(nic_params_list.length).to eq(2)
+      expect(nic_params_list[0][:ip_configurations]).to match([
+        a_hash_including(ip_version: 'IPv4', private_ip: '10.0.0.5')
+      ])
+      expect(nic_params_list[1][:ip_configurations].length).to eq(1)
+      expect(nic_params_list[1][:ip_configurations][0][:ip_version]).to eq('IPv4')
+    end
+  end
+
+  context 'when a vip network targets a secondary nic_group' do
+    let(:public_ip_address) { '203.0.113.10' }
+    let(:public_ip) { { id: 'fake-public-ip-id', ip_address: public_ip_address } }
+    let(:vip_network_for_second_nic) do
+      instance_double(
+        Bosh::AzureCloud::VipNetwork,
+        resource_group_name: MOCK_RESOURCE_GROUP_NAME,
+        public_ip: public_ip_address,
+        spec: { 'type' => 'vip', 'nic_group' => '2' }
+      )
+    end
+
+    before do
+      allow(network_configurator).to receive(:vip_network).and_return(vip_network_for_second_nic)
+      allow(network_configurator).to receive(:nic_groups)
+        .and_return([[manual_network_v4, manual_network_v6], [dynamic_net]])
+      allow(azure_client).to receive(:list_public_ips).and_return([public_ip])
+    end
+
+    it 'attaches the public IP to the NIC for that group' do
+      nic_params_list = capture_nic_params
+
+      expect(nic_params_list[0][:public_ip]).to be_nil
+      expect(nic_params_list[1][:public_ip]).to eq(public_ip)
+    end
+
+    context 'when the referenced nic_group does not exist' do
+      before do
+        allow(vip_network_for_second_nic).to receive(:spec)
+          .and_return({ 'type' => 'vip', 'nic_group' => 'missing' })
+      end
+
+      it 'fails instead of attaching the public IP to the primary NIC' do
+        expect { capture_nic_params }.to raise_error(
+          Bosh::Clouds::CloudError,
+          "Cannot find nic_group 'missing' referenced by the vip network"
+        )
+      end
+    end
+  end
+
+  context 'when a legacy vip network has no explicit nic_group' do
+    let(:public_ip_address) { '203.0.113.10' }
+    let(:public_ip) { { id: 'fake-public-ip-id', ip_address: public_ip_address } }
+    let(:legacy_vip_network) do
+      Bosh::AzureCloud::VipNetwork.new(
+        azure_config_managed,
+        'public',
+        { 'type' => 'vip', 'ip' => public_ip_address }
+      )
+    end
+
+    before do
+      allow(network_configurator).to receive(:vip_network).and_return(legacy_vip_network)
+      allow(network_configurator).to receive(:nic_groups)
+        .and_return([[manual_network_v4, manual_network_v6], [dynamic_net]])
+      allow(azure_client).to receive(:list_public_ips).and_return([public_ip])
+    end
+
+    it 'keeps attaching the public IP to the primary NIC' do
+      nic_params_list = capture_nic_params
+
+      expect(nic_params_list[0][:public_ip]).to eq(public_ip)
+      expect(nic_params_list[1][:public_ip]).to be_nil
+    end
+  end
+
+  describe '#_get_load_balancers' do
+    let(:backend_pool_name_v6) { 'pool-v6' }
+    let(:pool_v4) { { name: 'pool-v4', id: 'pool-v4-id' } }
+    let(:pool_v6) { { name: 'pool-v6', id: 'pool-v6-id' } }
+    let(:load_balancer) do
+      {
+        name: 'fake-lb-name',
+        backend_address_pools: [pool_v4, pool_v6]
+      }
+    end
+    let(:vm_properties) do
+      {
+        'instance_type' => 'Standard_D1',
+        'load_balancer' => {
+          'name' => 'fake-lb-name',
+          'backend_pool_name' => 'pool-v4',
+          'backend_pool_name_v6' => backend_pool_name_v6
+        }
+      }
+    end
+
+    it 'selects the configured backend pool for each IP family' do
+      result = vm_manager_ds.send(:_get_load_balancers, vm_props)
+
+      expect(result).to match([
+        a_hash_including(
+          backend_address_pools: [pool_v4],
+          backend_address_pools_v6: [pool_v6]
+        )
+      ])
+    end
+
+    context 'when the configured IPv6 backend pool does not exist' do
+      let(:backend_pool_name_v6) { 'missing-v6-pool' }
+
+      it 'raises a cloud error naming the missing pool' do
+        expect do
+          vm_manager_ds.send(:_get_load_balancers, vm_props)
+        end.to raise_error(
+          Bosh::Clouds::CloudError,
+          /does not have a backend_pool named 'missing-v6-pool'/
+        )
+      end
+    end
+  end
+
+end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dual_stack_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dual_stack_spec.rb
@@ -12,6 +12,12 @@ describe Bosh::AzureCloud::VMManager, 'dual-stack NIC creation' do
 
   let(:manual_network_v4) { build_manual_network(private_ip: '10.0.0.5', subnet_name: 'dual-stack-subnet') }
   let(:manual_network_v6) { build_manual_network(private_ip: 'fd00::5',  subnet_name: 'dual-stack-subnet') }
+  let(:interleaved_networks) do
+    Array.new(17) do |index|
+      private_ip = index.even? ? "10.0.0.#{index + 5}" : "fd00::#{index + 5}"
+      build_manual_network(private_ip: private_ip, subnet_name: 'dual-stack-subnet')
+    end
+  end
   let(:dynamic_net) do
     instance_double(Bosh::AzureCloud::DynamicNetwork).tap do |n|
       allow(n).to receive(:resource_group_name).and_return(MOCK_RESOURCE_GROUP_NAME)
@@ -78,6 +84,21 @@ describe Bosh::AzureCloud::VMManager, 'dual-stack NIC creation' do
         a_hash_including(name: 'ipconfig0-0', ip_version: 'IPv4', private_ip: '10.0.0.5', subnet: dual_stack_subnet),
         a_hash_including(name: 'ipconfig0-1', ip_version: 'IPv6', private_ip: 'fd00::5',  subnet: dual_stack_subnet)
       ])
+    end
+  end
+
+  context 'when a nic_group contains multiple networks of the same IP family' do
+    before do
+      allow(network_configurator).to receive(:nic_groups)
+        .and_return([interleaved_networks])
+    end
+
+    it 'keeps their relative order while placing IPv4 configurations before IPv6' do
+      nic = capture_nic_params.first
+      expected_ipv4 = (0...17).select(&:even?).map { |index| "10.0.0.#{index + 5}" }
+      expected_ipv6 = (0...17).select(&:odd?).map { |index| "fd00::#{index + 5}" }
+
+      expect(nic[:ip_configurations].map { |ipconfig| ipconfig[:private_ip] }).to eq(expected_ipv4 + expected_ipv6)
     end
   end
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dual_stack_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dual_stack_spec.rb
@@ -232,4 +232,21 @@ describe Bosh::AzureCloud::VMManager, 'dual-stack NIC creation' do
     end
   end
 
+  describe '#_build_nic_groups_to_iface' do
+    let(:group_one_v4) { instance_double(Bosh::AzureCloud::ManualNetwork, spec: { 'nic_group' => '1' }) }
+    let(:group_one_v6) { instance_double(Bosh::AzureCloud::ManualNetwork, spec: { 'nic_group' => '1' }) }
+    let(:ungrouped) { instance_double(Bosh::AzureCloud::DynamicNetwork, spec: { 'type' => 'dynamic' }) }
+    let(:group_two) { instance_double(Bosh::AzureCloud::ManualNetwork, spec: { 'nic_group' => '2' }) }
+
+    before do
+      allow(network_configurator).to receive(:nic_groups)
+        .and_return([[group_one_v4, group_one_v6], [ungrouped], [group_two]])
+    end
+
+    it 'maps explicit groups to their NIC attachment order and omits implicit groups' do
+      mapping = vm_manager_ds.send(:_build_nic_groups_to_iface, network_configurator)
+
+      expect(mapping).to eq('1' => 'eth0', '2' => 'eth2')
+    end
+  end
 end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/dynamic_public_ip_spec.rb
@@ -66,7 +66,7 @@ describe Bosh::AzureCloud::VMManager do
                   .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
                                                     name: "#{vm_name}-0",
                                                     public_ip: dynamic_public_ip,
-                                                    subnet: subnet,
+                                                    ip_configurations: [hash_including(subnet: subnet)],
                                                     tags: tags,
                                                     load_balancers: [load_balancer],
                                                     application_gateways: [application_gateway]
@@ -190,7 +190,7 @@ describe Bosh::AzureCloud::VMManager do
                   .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
                                                     name: "#{vm_name}-0",
                                                     public_ip: dynamic_public_ip,
-                                                    subnet: subnet,
+                                                    ip_configurations: [hash_including(subnet: subnet)],
                                                     tags: tags,
                                                     load_balancers: load_balancer,
                                                     application_gateways: [application_gateway]
@@ -297,7 +297,7 @@ describe Bosh::AzureCloud::VMManager do
                   .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
                                                     name: "#{vm_name}-0",
                                                     public_ip: dynamic_public_ip,
-                                                    subnet: subnet,
+                                                    ip_configurations: [hash_including(subnet: subnet)],
                                                     tags: tags,
                                                     load_balancers: [load_balancer],
                                                     application_gateways: [application_gateway]
@@ -422,7 +422,7 @@ describe Bosh::AzureCloud::VMManager do
                   .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
                                                     name: "#{vm_name}-0",
                                                     public_ip: dynamic_public_ip,
-                                                    subnet: subnet,
+                                                    ip_configurations: [hash_including(subnet: subnet)],
                                                     tags: tags,
                                                     load_balancers: [load_balancer],
                                                     application_gateways: application_gateway
@@ -537,7 +537,7 @@ describe Bosh::AzureCloud::VMManager do
             expect(azure_client).to receive(:create_network_interface)
               .with(MOCK_RESOURCE_GROUP_NAME, hash_including(
                                                 public_ip: dynamic_public_ip,
-                                                subnet: subnet,
+                                                ip_configurations: [hash_including(subnet: subnet)],
                                                 tags: tags,
                                                 load_balancers: [load_balancer],
                                                 application_gateways: [application_gateway]

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -171,6 +171,8 @@ shared_context 'shared stuff for vm manager' do
       .and_return(vip_network)
     allow(network_configurator).to receive(:networks)
       .and_return([manual_network, dynamic_network])
+    allow(network_configurator).to receive(:nic_groups)
+      .and_return([[manual_network], [dynamic_network]])
     allow(network_configurator).to receive(:default_dns)
       .and_return('fake-dns')
 
@@ -183,6 +185,8 @@ shared_context 'shared stuff for vm manager' do
     allow(vip_network).to receive(:public_ip)
       .and_return('public-ip')
 
+    allow(manual_network).to receive(:spec)
+      .and_return({ 'type' => 'manual', 'ip' => 'private-ip' })
     allow(manual_network).to receive(:resource_group_name)
       .and_return(MOCK_RESOURCE_GROUP_NAME)
     allow(manual_network).to receive(:virtual_network_name)
@@ -200,6 +204,8 @@ shared_context 'shared stuff for vm manager' do
     allow(manual_network).to receive(:accelerated_networking)
       .and_return(false)
 
+    allow(dynamic_network).to receive(:spec)
+      .and_return({ 'type' => 'dynamic' })
     allow(dynamic_network).to receive(:resource_group_name)
       .and_return(MOCK_RESOURCE_GROUP_NAME)
     allow(dynamic_network).to receive(:virtual_network_name)

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -184,6 +184,8 @@ shared_context 'shared stuff for vm manager' do
                   }])
     allow(vip_network).to receive(:public_ip)
       .and_return('public-ip')
+    allow(vip_network).to receive(:spec)
+      .and_return({ 'type' => 'vip' })
 
     allow(manual_network).to receive(:spec)
       .and_return({ 'type' => 'manual', 'ip' => 'private-ip' })


### PR DESCRIPTION
> [!IMPORTANT]
> ~Depends-on: #745 -> #744~
> ~Rebase before merging; current branch is based on [`s4heid:refactor/azure-client-ip-configurations`](https://github.com/s4heid/bosh-azure-cpi-release/tree/refactor/azure-client-ip-configurations)~

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero errors (after my changes)

# Changelog

* IPv6 dual-stack support for Azure VMs. NICs can now host both IPv4 and IPv6 ipConfigurations, enabling RFC-0038 dual-stack deployments.
* `nic_group` network property: multiple BOSH networks sharing the same `nic_group` value are placed on the same Azure NIC.
* `backend_pool_name_v6` on load balancer config: routes IPv6 ipConfigurations to a separate IPv6 backend pool. IPv4 routing and Application Gateway behavior are unchanged.
* Agent network settings now include an alias field (eth0, eth1, …) per `nic_group`, so the bosh-agent can bind both IPv4 and IPv6 networks to the correct shared NIC.