### PR TITLE
ci: Fix terraform usage for 5.0 Azure provider

### DIFF
--- a/ci/assets/terraform/integration/template.tf
+++ b/ci/assets/terraform/integration/template.tf
@@ -92,7 +92,7 @@ resource "azurerm_storage_container" "azure_stemcell_container" {
 # Create a Storage Table for the metadata of the stemcells
 resource "azurerm_storage_table" "azure_stemcells_table" {
   name                 = "stemcells"
-  storage_account_name = azurerm_storage_account.azure_bosh_sa.name
+  storage_account_id = azurerm_storage_account.azure_bosh_sa.id
 }
 
 # Create an extra Storage Account in the azure_default_rg resource group


### PR DESCRIPTION
The latest Azure provider has switched storage accounts to use IDs instead of names (consistent with other resources in the Azure provider).

ai-assisted=no
[TNZ-88995] [Europa] Bosh KTLO

--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

Thanks for submitting a pull request!

All pull request submitters and commit authors must have a Contributor License Agreement (CLA) on-file with us. Please sign the appropriate CLA ([individual](http://cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf) or [corporate](http://cloudfoundry.org/pdfs/CFF_Corporate_CLA.pdf)).

When sending signed CLA please provide your github username in case of individual CLA or the list of github usernames that can make pull requests on behalf of your organization.

If you are confident that you're covered under a Corporate CLA, please make sure you've publicized your membership in the appropriate Github Org, per [these instructions](https://help.github.com/articles/publicizing-or-concealing-organization-membership/).

--------------------MESSAGE FROM ADMIN, DELETE BEFORE SUBMITTING----------------------

# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All unit tests pass locally (after my changes)
- [ ] Rubocop reports zero errors (after my changes)

# Changelog

* 
* 
* 
