### PR TITLE
Fix application_gateway_spec integration spec

### DIFF
--- a/src/bosh_azure_cpi/spec/integration/resources/application_gateway_spec.rb
+++ b/src/bosh_azure_cpi/spec/integration/resources/application_gateway_spec.rb
@@ -64,7 +64,7 @@ describe Bosh::AzureCloud::Cloud do
       threads.times do |i|
         lifecycles[i] = Thread.new do
           agent_id = SecureRandom.uuid
-          ip_config_id = "/subscriptions/#{@subscription_id}/resourceGroups/#{@default_resource_group_name}/providers/Microsoft.Network/networkInterfaces/#{agent_id}-0/ipConfigurations/ipconfig0"
+          ip_config_id = "/subscriptions/#{@subscription_id}/resourceGroups/#{@default_resource_group_name}/providers/Microsoft.Network/networkInterfaces/#{agent_id}-0/ipConfigurations/ipconfig0-0"
           begin
             new_instance_id = @cpi.create_vm(
               agent_id,


### PR DESCRIPTION
# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero errors (after my changes)

# Changelog

* PR #746 renamed IP configurations from `ipconfig0` to `ipconfig0-0`. The integration expectation now uses the updated Azure resource ID for both attachment and cleanup assertions.