### PR TITLE
Update GEM files to fix syslog warning

### DIFF
--- a/src/bosh_azure_cpi/Gemfile
+++ b/src/bosh_azure_cpi/Gemfile
@@ -12,6 +12,7 @@ gem 'jwt'
 gem 'deep_merge'
 gem 'net-smtp'
 gem 'ostruct'
+gem 'syslog'
 
 group :development, :test do
   gem 'rake'

--- a/src/bosh_azure_cpi/Gemfile.lock
+++ b/src/bosh_azure_cpi/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
     ruby2_keywords (0.0.5)
     semi_semantic (1.2.0)
     simplecov (1.1.1)
+    syslog (0.1.2)
     timeout (0.6.1)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
@@ -168,6 +169,7 @@ DEPENDENCIES
   rspec-retry
   rubocop
   simplecov
+  syslog
   webmock
 
 BUNDLED WITH

--- a/src/bosh_azure_cpi/vendor/package/syslog-0.1.2.gem
+++ b/src/bosh_azure_cpi/vendor/package/syslog-0.1.2.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:599ba10f64d9dc868abc5e4d4ad6a356f0651214df4b05f561815d69b37cb88b
+size 14848


### PR DESCRIPTION
# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero errors (after my changes)

# Changelog

* Added `syslog` as an explicit dependency because it will no longer be a default gem starting with Ruby 3.4.
* Updated `Gemfile.lock` with the resolved `syslog` dependency.
* Prevented the Ruby compatibility warning emitted while loading the `logging` dependency.

Fixes the following issue: #757 
