### PR TITLE
Retry conflicting VM metadata updates

### DIFF
--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -582,12 +582,23 @@ module Bosh::AzureCloud
     #
     def update_tags_of_virtual_machine(resource_group_name, name, tags)
       url = rest_api_url(REST_API_PROVIDER_COMPUTE, REST_API_VIRTUAL_MACHINES, resource_group_name: resource_group_name, name: name)
-      vm = get_resource_by_id(url)
-      raise AzureNotFoundError, "update_tags_of_virtual_machine - cannot find the virtual machine by name '#{name}' in resource group '#{resource_group_name}'" if vm.nil?
+      retry_count = 0
+      begin
+        vm = get_resource_by_id(url)
+        raise AzureNotFoundError, "update_tags_of_virtual_machine - cannot find the virtual machine by name '#{name}' in resource group '#{resource_group_name}'" if vm.nil?
 
-      vm = remove_resources_from_vm(vm)
-      vm['tags'].merge!(tags)
-      http_put(url, vm)
+        vm = remove_resources_from_vm(vm)
+        vm['tags'].merge!(tags)
+        http_put(url, vm)
+      rescue AzureConflictError => e
+        if conflicting_concurrent_write_not_allowed?(e) && retry_count < AZURE_MAX_RETRY_COUNT
+          retry_count += 1
+          @logger.warn("update_tags_of_virtual_machine - concurrent write conflict. Will retry after 5 seconds.")
+          sleep(5)
+          retry
+        end
+        raise e
+      end
     end
 
     # Attach a specified disk to a virtual machine
@@ -3218,6 +3229,13 @@ module Bosh::AzureCloud
         end
       end
       vm
+    end
+
+    def conflicting_concurrent_write_not_allowed?(error)
+      response_body = error.message[/\Ahttp_put - http code: 409\n.*\nError message: (.*)\z/m, 1]
+      JSON.parse(response_body).dig('error', 'code') == 'ConflictingConcurrentWriteNotAllowed'
+    rescue JSON::ParserError, TypeError
+      false
     end
   end
 end

--- a/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/restapi/azure_client.rb
@@ -3233,7 +3233,8 @@ module Bosh::AzureCloud
 
     def conflicting_concurrent_write_not_allowed?(error)
       response_body = error.message[/\Ahttp_put - http code: 409\n.*\nError message: (.*)\z/m, 1]
-      JSON.parse(response_body).dig('error', 'code') == 'ConflictingConcurrentWriteNotAllowed'
+      response = JSON.parse(response_body)
+      response.is_a?(Hash) && response.dig('error', 'code') == 'ConflictingConcurrentWriteNotAllowed'
     rescue JSON::ParserError, TypeError
       false
     end

--- a/src/bosh_azure_cpi/spec/unit/azure_client/update_tags_of_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/update_tags_of_virtual_machine_spec.rb
@@ -105,6 +105,135 @@ describe Bosh::AzureCloud::AzureClient do
             azure_client.update_tags_of_virtual_machine(resource_group, vm_name, tags)
           end.not_to raise_error
         end
+
+        it 'retries the complete update when Azure rejects a concurrent write' do
+          allow(logger).to receive(:warn)
+          stub_request(:post, token_uri).to_return(
+            status: 200,
+            body: {
+              'access_token' => valid_access_token,
+              'expires_on' => expires_on
+            }.to_json,
+            headers: {}
+          )
+          stub_request(:get, vm_uri).to_return(
+            status: 200,
+            body: exiting_vm,
+            headers: {}
+          )
+          stub_request(:put, vm_uri).with(body: updated_vm).to_return(
+            {
+              status: 409,
+              body: '{"error":{"code":"ConflictingConcurrentWriteNotAllowed"}}',
+              headers: {}
+            },
+            {
+              status: 200,
+              body: '',
+              headers: {
+                'azure-asyncoperation' => operation_status_link
+              }
+            }
+          )
+          stub_request(:get, operation_status_link).to_return(
+            status: 200,
+            body: '{"status":"Succeeded"}',
+            headers: {}
+          )
+
+          expect do
+            azure_client.update_tags_of_virtual_machine(resource_group, vm_name, tags)
+          end.not_to raise_error
+          expect(a_request(:get, vm_uri)).to have_been_requested.times(2)
+          expect(a_request(:put, vm_uri).with(body: updated_vm)).to have_been_requested.times(2)
+          expect(a_request(:get, operation_status_link)).to have_been_requested.once
+          expect(azure_client).to have_received(:sleep).with(5).twice
+          expect(logger).to have_received(:warn).with('update_tags_of_virtual_machine - concurrent write conflict. Will retry after 5 seconds.').once
+        end
+
+        it 'stops retrying concurrent writes after the retry limit' do
+          stub_request(:post, token_uri).to_return(
+            status: 200,
+            body: {
+              'access_token' => valid_access_token,
+              'expires_on' => expires_on
+            }.to_json,
+            headers: {}
+          )
+          stub_request(:get, vm_uri).to_return(
+            status: 200,
+            body: exiting_vm,
+            headers: {}
+          )
+          stub_request(:put, vm_uri).with(body: updated_vm).to_return(
+            status: 409,
+            body: '{"error":{"code":"ConflictingConcurrentWriteNotAllowed"}}',
+            headers: {}
+          )
+
+          expect do
+            azure_client.update_tags_of_virtual_machine(resource_group, vm_name, tags)
+          end.to raise_error Bosh::AzureCloud::AzureConflictError
+          expect(a_request(:get, vm_uri)).to have_been_requested.times(AZURE_MAX_RETRY_COUNT + 1)
+          expect(a_request(:put, vm_uri).with(body: updated_vm)).to have_been_requested.times(AZURE_MAX_RETRY_COUNT + 1)
+          expect(azure_client).to have_received(:sleep).with(5).exactly(AZURE_MAX_RETRY_COUNT).times
+        end
+
+        it 'does not retry other Azure conflict errors' do
+          stub_request(:post, token_uri).to_return(
+            status: 200,
+            body: {
+              'access_token' => valid_access_token,
+              'expires_on' => expires_on
+            }.to_json,
+            headers: {}
+          )
+          stub_request(:get, vm_uri).to_return(
+            status: 200,
+            body: exiting_vm,
+            headers: {}
+          )
+          stub_request(:put, vm_uri).with(body: updated_vm).to_return(
+            status: 409,
+            body: '{"error":{"code":"AnotherConflict"}}',
+            headers: {}
+          )
+
+          expect do
+            azure_client.update_tags_of_virtual_machine(resource_group, vm_name, tags)
+          end.to raise_error Bosh::AzureCloud::AzureConflictError
+          expect(a_request(:put, vm_uri).with(body: updated_vm)).to have_been_requested.once
+          expect(azure_client).not_to have_received(:sleep)
+        end
+
+        it 'does not retry conflicts with the concurrent-write phrase outside the error body' do
+          stub_request(:post, token_uri).to_return(
+            status: 200,
+            body: {
+              'access_token' => valid_access_token,
+              'expires_on' => expires_on
+            }.to_json,
+            headers: {}
+          )
+          stub_request(:get, vm_uri).to_return(
+            status: 200,
+            body: exiting_vm,
+            headers: {}
+          )
+          stub_request(:put, vm_uri).with(body: updated_vm).to_return(
+            status: 409,
+            body: 'not JSON',
+            headers: {
+              'x-ms-request-id' => 'ConflictingConcurrentWriteNotAllowed'
+            }
+          )
+
+          expect do
+            azure_client.update_tags_of_virtual_machine(resource_group, vm_name, tags)
+          end.to raise_error Bosh::AzureCloud::AzureConflictError
+          expect(a_request(:put, vm_uri).with(body: updated_vm)).to have_been_requested.once
+          expect(azure_client).not_to have_received(:sleep)
+        end
       end
 
       context "when VM's information doesn't contain tags" do

--- a/src/bosh_azure_cpi/spec/unit/azure_client/update_tags_of_virtual_machine_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/azure_client/update_tags_of_virtual_machine_spec.rb
@@ -234,6 +234,33 @@ describe Bosh::AzureCloud::AzureClient do
           expect(a_request(:put, vm_uri).with(body: updated_vm)).to have_been_requested.once
           expect(azure_client).not_to have_received(:sleep)
         end
+
+        it 'does not retry conflicts with a null error body' do
+          stub_request(:post, token_uri).to_return(
+            status: 200,
+            body: {
+              'access_token' => valid_access_token,
+              'expires_on' => expires_on
+            }.to_json,
+            headers: {}
+          )
+          stub_request(:get, vm_uri).to_return(
+            status: 200,
+            body: exiting_vm,
+            headers: {}
+          )
+          stub_request(:put, vm_uri).with(body: updated_vm).to_return(
+            status: 409,
+            body: 'null',
+            headers: {}
+          )
+
+          expect do
+            azure_client.update_tags_of_virtual_machine(resource_group, vm_name, tags)
+          end.to raise_error Bosh::AzureCloud::AzureConflictError
+          expect(a_request(:put, vm_uri).with(body: updated_vm)).to have_been_requested.once
+          expect(azure_client).not_to have_received(:sleep)
+        end
       end
 
       context "when VM's information doesn't contain tags" do


### PR DESCRIPTION
## Summary
- retry VM metadata read-modify-write updates when Azure returns `ConflictingConcurrentWriteNotAllowed`
- re-fetch the VM before each retry and preserve all other conflict behavior
- cover success, exhaustion, non-matching errors, malformed bodies, and async completion

Closes #762

## Test Plan
- [x] `bundle exec rspec spec/unit/azure_client/update_tags_of_virtual_machine_spec.rb spec/unit/vm_manager/set_metadata_spec.rb` (9 examples, 0 failures)
- [ ] Full suite requires `BOSH_AZURE_*` integration credentials; without them, integration specs fail during setup