### PR TITLE
Make VM size selection architecture-aware

### DIFF
--- a/docs/advanced/calculate-vm-cloud-properties/README.md
+++ b/docs/advanced/calculate-vm-cloud-properties/README.md
@@ -61,6 +61,8 @@ The returned Azure specific cloud properites contain two parts: `instance_type` 
 
     The `closest matched` is defined by Azure CPI. Please note VM size is determined on best effort basis. Azure CPI tries to select the VM size with the balance of cost and performance.
 
+1. When the VM is created, CPI filters the calculated VM sizes using the stemcell architecture and Azure's `CpuArchitectureType` capability. Stemcells without architecture metadata and legacy VM sizes without this capability are treated as x64. Explicitly configured `instance_type` values are not filtered.
+
     CPI maintains a table of recommended VM sizes. Please check [`RECOMMENDED_VM_SIZES`](https://github.com/cloudfoundry/bosh-azure-cpi-release/blob/master/src/bosh_azure_cpi/lib/cloud/azure/instance_type_mapper.rb). The table may **CHANGE** in future.
 
     CPI searches each series in the table from the top to the bottom, and selects the VM sizes which are also in the list of possible VM sizes. It means these VM sizes statisfy the requirements of `vm_resources`.

--- a/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb
@@ -842,8 +842,8 @@ module Bosh::AzureCloud
       @disk_manager2           = Bosh::AzureCloud::DiskManager2.new(@azure_client)
       @stemcell_manager2       = Bosh::AzureCloud::StemcellManager2.new(_azure_config, @blob_manager, @meta_store, @storage_account_manager, @azure_client)
       @light_stemcell_manager  = Bosh::AzureCloud::LightStemcellManager.new(@blob_manager, @storage_account_manager, @azure_client)
-      @vm_manager              = Bosh::AzureCloud::VMManager.new(_azure_config, @disk_manager, @disk_manager2, @azure_client, @storage_account_manager, @stemcell_manager, @stemcell_manager2, @light_stemcell_manager)
       @instance_type_mapper    = Bosh::AzureCloud::InstanceTypeMapper.new(@azure_client)
+      @vm_manager              = Bosh::AzureCloud::VMManager.new(_azure_config, @disk_manager, @disk_manager2, @azure_client, @storage_account_manager, @stemcell_manager, @stemcell_manager2, @light_stemcell_manager, @instance_type_mapper)
     rescue Net::OpenTimeout => e
       cloud_error("Please make sure the CPI has proper network access to Azure. #{e.inspect}") # TODO: Will it throw the error when initializing the client and manager
     end

--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell/compute_gallery_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell/compute_gallery_manager.rb
@@ -195,18 +195,6 @@ module Bosh::AzureCloud
       normalized_os_type
     end
 
-    def normalize_architecture(arch)
-      return nil if arch.nil? || arch.empty?
-      case arch.to_s.downcase
-      when 'x86_64', 'x64'
-        'x64'
-      when 'arm64'
-        'Arm64'
-      else
-        arch
-      end
-    end
-
     def normalize_disk_controllers(disk_controllers)
       disk_controllers.map do |controller|
         case controller.to_s.downcase
@@ -227,7 +215,7 @@ module Bosh::AzureCloud
 
     def build_image_definition_params(location, metadata)
       os_type = normalize_os_type(metadata['os_type'])
-      architecture = normalize_architecture(metadata['architecture'])
+      architecture = CpuArchitecture.normalize(metadata['architecture'])
       image_metadata = JSON.parse(metadata['image'])
       hyperv_generation = build_hyperv_generation(metadata)
       features = build_features_array(metadata)

--- a/src/bosh_azure_cpi/lib/cloud/azure/stemcell/stemcell_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/stemcell/stemcell_manager.rb
@@ -73,6 +73,10 @@ module Bosh::AzureCloud
       StemcellInfo.new(uri, metadata)
     end
 
+    def get_stemcell_architecture(name)
+      get_stemcell_info(@default_storage_account_name, name).architecture
+    end
+
     private
 
     def _handle_stemcell_in_different_storage_account(storage_account_name, name)

--- a/src/bosh_azure_cpi/lib/cloud/azure/utils/helpers.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/utils/helpers.rb
@@ -86,6 +86,26 @@ module Bosh::AzureCloud
     SKU_TIER_STANDARD = 'Standard'
     SKU_TIER_PREMIUM  = 'Premium'
 
+    module CpuArchitecture
+      X64 = 'x64'
+      ARM64 = 'Arm64'
+
+      module_function
+
+      def normalize(architecture)
+        return nil if architecture.nil? || architecture.to_s.empty?
+
+        case architecture.to_s.downcase
+        when 'x86_64', 'amd64', 'x64'
+          X64
+        when 'aarch64', 'arm64'
+          ARM64
+        else
+          architecture.to_s
+        end
+      end
+    end
+
     # Storage Account
     STORAGE_ACCOUNT_TYPE_STANDARD_LRS    = 'Standard_LRS'
     STORAGE_ACCOUNT_TYPE_STANDARDSSD_LRS = 'StandardSSD_LRS'
@@ -487,6 +507,7 @@ module Bosh::AzureCloud
     # * +:os_type+     - String. os type of the stemcell, e.g. "linux"
     # * +:name+        - String. name of the stemcell, e.g. "bosh-azure-hyperv-ubuntu-trusty-go_agent"
     # * +:version      - String. version of the stemcell, e.g. "2972"
+    # * +:architecture+ - String. normalized Azure CPU architecture, e.g. "x64" or "Arm64".
     # * +:image_size   - Integer. size in MiB of the image.
     #                             For a normal stemcell, the value should be the size of root.vhd.
     #                             For a light stemcell, the value should be the size of the platform image.
@@ -496,12 +517,13 @@ module Bosh::AzureCloud
     # *   +sku+          - String. The sku of the publisher's offer.
     # *   +version+      - String. The version of the sku.
     class StemcellInfo
-      attr_reader :uri, :metadata, :os_type, :name, :version, :image_size, :image
+      attr_reader :uri, :metadata, :os_type, :name, :version, :image_size, :image, :architecture
 
       def initialize(uri, metadata)
         @uri = uri
         @metadata = metadata
         @os_type = @metadata['os_type'].nil? ? 'linux' : @metadata['os_type'].downcase
+        @architecture = CpuArchitecture.normalize(@metadata['architecture']) || CpuArchitecture::X64
         @name = @metadata['name']
         @version = @metadata['version']
         @image_size = if @metadata['disk'].nil?

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/instance_type_mapper.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/instance_type_mapper.rb
@@ -4,6 +4,8 @@ module Bosh::AzureCloud
   class InstanceTypeMapper
     include Helpers
 
+    class SkuLookupError < StandardError; end
+
     SERIES_PREFERENCE = {
       'D' => 5,  # General purpose - balanced
       'F' => 4,  # Compute optimized
@@ -58,6 +60,28 @@ module Bosh::AzureCloud
 
       @logger.debug("Selected VM sizes (in order): #{closest_matched_vm_sizes.join(', ')}")
       closest_matched_vm_sizes
+    rescue SkuLookupError
+      cloud_error("Unable to meet desired instance size: #{desired_instance_size['cpu']} CPU, #{desired_instance_size['ram']} MB RAM")
+    end
+
+    def filter_by_architecture(instance_types, architecture, location)
+      normalized_architecture = CpuArchitecture.normalize(architecture) || CpuArchitecture::X64
+      sku_architectures = get_vm_skus(location).each_with_object({}) do |sku, architectures|
+        next if sku[:name].nil?
+
+        capabilities = sku[:capabilities] || {}
+        sku_architecture = CpuArchitecture.normalize(capabilities[:CpuArchitectureType]) || CpuArchitecture::X64
+        architectures[sku[:name].downcase] = sku_architecture
+      end
+
+      compatible_instance_types = instance_types.select do |instance_type|
+        sku_architectures[instance_type.downcase] == normalized_architecture
+      end
+
+      @logger.debug(
+        "VM sizes compatible with CPU architecture '#{normalized_architecture}': #{compatible_instance_types.join(', ')}"
+      )
+      compatible_instance_types
     end
 
     private
@@ -65,16 +89,15 @@ module Bosh::AzureCloud
     def get_vm_skus(location)
       cache_key = "skus-#{location}"
       unless @sku_cache[cache_key]
-        begin
-          @logger.debug("Fetching VM SKU information for location: #{location}")
-          @sku_cache[cache_key] = @azure_client.list_vm_skus(location)
-        rescue => e
-          @logger.warn("Failed to fetch VM SKU information: #{e.message}")
-          return []
-        end
+        @logger.debug("Fetching VM SKU information for location: #{location}")
+        @sku_cache[cache_key] = @azure_client.list_vm_skus(location)
       end
 
       @sku_cache[cache_key]
+    rescue => e
+      message = "Failed to fetch VM SKU information: #{e.message}"
+      @logger.warn(message)
+      raise SkuLookupError, message
     end
 
     def extract_generation(vm_name)

--- a/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
+++ b/src/bosh_azure_cpi/lib/cloud/azure/vms/vm_manager.rb
@@ -4,7 +4,7 @@ module Bosh::AzureCloud
   class VMManager
     include Helpers
 
-    def initialize(azure_config, disk_manager, disk_manager2, azure_client, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager)
+    def initialize(azure_config, disk_manager, disk_manager2, azure_client, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager, instance_type_mapper = nil)
       @azure_config = azure_config
       @disk_manager = disk_manager
       @disk_manager2 = disk_manager2
@@ -13,6 +13,7 @@ module Bosh::AzureCloud
       @stemcell_manager = stemcell_manager
       @stemcell_manager2 = stemcell_manager2
       @light_stemcell_manager = light_stemcell_manager
+      @instance_type_mapper = instance_type_mapper || InstanceTypeMapper.new(azure_client)
       @use_managed_disks = azure_config.use_managed_disks
       @logger = Bosh::Clouds::Config.logger
     end
@@ -69,12 +70,24 @@ module Bosh::AzureCloud
           end
 
           cloud_error('No available instance type is found.') if calculated_instance_types.empty?
-          vm_props.instance_type = calculated_instance_types[0]
         end
       else
         availability_set_name = nil
-        vm_props.instance_type = vm_props.instance_types[0] if vm_props.instance_type.nil?
       end
+
+      if vm_props.instance_type.nil?
+        stemcell_architecture = _get_stemcell_architecture(bosh_vm_meta.stemcell_cid)
+        calculated_instance_types = @instance_type_mapper.filter_by_architecture(
+          calculated_instance_types,
+          stemcell_architecture,
+          location
+        )
+        if calculated_instance_types.empty?
+          cloud_error("No available instance type supports stemcell architecture '#{stemcell_architecture}' in location '#{location}'.")
+        end
+        vm_props.instance_type = calculated_instance_types[0]
+      end
+
       @logger.info("The instance type is '#{vm_props.instance_type}'")
 
       # tasks to prepare resources for VM
@@ -287,7 +300,8 @@ module Bosh::AzureCloud
 
       # Replace vmSize with instance_type because only instance_type exists in the manifest
       error_message = error_message.gsub!('vmSize', 'instance_type') if error_message.include?('vmSize')
-      raise Bosh::Clouds::VMCreationFailed.new(false), "#{error_message}\n#{e.backtrace.join("\n")}"
+      ok_to_retry = e.is_a?(InstanceTypeMapper::SkuLookupError)
+      raise Bosh::Clouds::VMCreationFailed.new(ok_to_retry), "#{error_message}\n#{e.backtrace.join("\n")}"
     end
 
     def find(instance_id)
@@ -457,6 +471,18 @@ module Bosh::AzureCloud
     end
 
     private
+
+    def _get_stemcell_architecture(stemcell_cid)
+      architecture = if is_light_stemcell_cid?(stemcell_cid)
+                       @light_stemcell_manager.get_stemcell_info(stemcell_cid).architecture
+                     elsif @use_managed_disks
+                       @stemcell_manager2.get_stemcell_architecture(stemcell_cid)
+                     else
+                       @stemcell_manager.get_stemcell_architecture(stemcell_cid)
+                     end
+      @logger.debug("get_stemcell_architecture - got '#{architecture}' for stemcell '#{stemcell_cid}'")
+      architecture
+    end
 
     def _build_instance_id(bosh_vm_meta, location, vm_props)
       if @use_managed_disks

--- a/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/helpers_spec.rb
@@ -753,6 +753,7 @@ describe Bosh::AzureCloud::Helpers do
           expect(stemcell_info.name).to eq('fake-name')
           expect(stemcell_info.version).to eq('fake-version')
           expect(stemcell_info.image_size).to eq(3072)
+          expect(stemcell_info.architecture).to eq('x64')
           expect(stemcell_info.is_light_stemcell?).to be(false)
           expect(stemcell_info.image_reference).to be(nil)
         end
@@ -860,6 +861,20 @@ describe Bosh::AzureCloud::Helpers do
       end
     end
 
+    context 'when architecture is arm64' do
+      let(:metadata) do
+        {
+          'architecture' => 'aarch64'
+        }
+      end
+
+      it 'normalizes the architecture for Azure' do
+        stemcell_info = Bosh::AzureCloud::Helpers::StemcellInfo.new('fake-uri', metadata)
+
+        expect(stemcell_info.architecture).to eq('Arm64')
+      end
+    end
+
     context 'when metadata is empty' do
       let(:uri) { 'fake-uri' }
       let(:metadata) { {} }
@@ -871,6 +886,7 @@ describe Bosh::AzureCloud::Helpers do
         expect(stemcell_info.name).to be(nil)
         expect(stemcell_info.version).to be(nil)
         expect(stemcell_info.image_size).to eq(3072)
+        expect(stemcell_info.architecture).to eq('x64')
       end
     end
   end

--- a/src/bosh_azure_cpi/spec/unit/instance_type_mapper_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/instance_type_mapper_spec.rb
@@ -444,4 +444,59 @@ describe Bosh::AzureCloud::InstanceTypeMapper do
       end
     end
   end
+
+  describe '#filter_by_architecture' do
+    let(:azure_skus) do
+      [
+        {
+          name: 'Standard_D2s_v5',
+          capabilities: {
+            CpuArchitectureType: 'x64'
+          }
+        },
+        {
+          name: 'Standard_D2ps_v5',
+          capabilities: {
+            CpuArchitectureType: 'Arm64'
+          }
+        },
+        {
+          name: 'Standard_D2_v3',
+          capabilities: {}
+        }
+      ]
+    end
+
+    let(:instance_types) { %w[Standard_D2ps_v5 Standard_D2_v3 Standard_D2s_v5] }
+
+    before do
+      allow(azure_client).to receive(:list_vm_skus).with(location).and_return(azure_skus)
+    end
+
+    it 'returns only VM sizes matching an ARM64 stemcell' do
+      expect(subject.filter_by_architecture(instance_types, 'aarch64', location)).to eq(['Standard_D2ps_v5'])
+    end
+
+    it 'normalizes x86_64 and treats SKUs without the capability as x64' do
+      expect(subject.filter_by_architecture(instance_types, 'x86_64', location)).to eq(
+        %w[Standard_D2_v3 Standard_D2s_v5]
+      )
+    end
+
+    it 'defaults to x64 when stemcell architecture metadata is absent' do
+      expect(subject.filter_by_architecture(instance_types, nil, location)).to eq(
+        %w[Standard_D2_v3 Standard_D2s_v5]
+      )
+    end
+
+    it 'preserves VM SKU lookup failures' do
+      allow(azure_client).to receive(:list_vm_skus).with(location)
+                                                        .and_raise(Bosh::AzureCloud::AzureError.new('Azure API error'))
+      expect(logger).to receive(:warn).with(/Failed to fetch VM SKU information: Azure API error/)
+
+      expect do
+        subject.filter_by_architecture(instance_types, 'arm64', location)
+      end.to raise_error(Bosh::AzureCloud::InstanceTypeMapper::SkuLookupError, /Failed to fetch VM SKU information/)
+    end
+  end
 end

--- a/src/bosh_azure_cpi/spec/unit/stemcell_manager_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/stemcell_manager_spec.rb
@@ -400,5 +400,22 @@ describe Bosh::AzureCloud::StemcellManager do
         expect(stemcell_info.metadata).to eq(stemcell_blob_metadata)
       end
     end
+
+    describe '#get_stemcell_architecture' do
+      let(:stemcell_container) { 'stemcell' }
+
+      before do
+        allow(blob_manager).to receive(:get_blob_uri)
+          .with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd")
+          .and_return('fake-blob-url')
+        allow(blob_manager).to receive(:get_blob_metadata)
+          .with(MOCK_DEFAULT_STORAGE_ACCOUNT_NAME, stemcell_container, "#{stemcell_name}.vhd")
+          .and_return('architecture' => 'aarch64')
+      end
+
+      it 'reads normalized architecture from the default stemcell blob' do
+        expect(stemcell_manager.get_stemcell_architecture(stemcell_name)).to eq('Arm64')
+      end
+    end
   end
 end

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/availability_set_spec.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/availability_set_spec.rb
@@ -81,6 +81,83 @@ describe Bosh::AzureCloud::VMManager do
             )
           end
 
+          context 'when the stemcell is ARM64' do
+            let(:instance_types) { %w[Standard_D2s_v5 Standard_D2ps_v5] }
+            let(:disk_cids) { nil }
+            let(:available_vm_sizes) do
+              instance_types.map do |instance_type|
+                {
+                  name: instance_type,
+                  number_of_cores: '2',
+                  memory_in_mb: 4096
+                }
+              end
+            end
+
+            before do
+              allow(stemcell_manager).to receive(:get_stemcell_architecture).with(stemcell_cid).and_return('Arm64')
+              allow(stemcell_manager2).to receive(:get_stemcell_architecture).with(stemcell_cid).and_return('Arm64')
+              allow(azure_client).to receive(:list_available_virtual_machine_sizes_by_availability_set)
+                .with(MOCK_RESOURCE_GROUP_NAME, vm_props.availability_set.name)
+                .and_return(available_vm_sizes)
+            end
+
+            it 'selects an instance type compatible with the stemcell architecture' do
+              expect(instance_type_mapper).to receive(:filter_by_architecture)
+                .with(instance_types, 'Arm64', location)
+                .and_return(['Standard_D2ps_v5'])
+
+              vm_manager.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+
+              expect(vm_props.instance_type).to eq('Standard_D2ps_v5')
+            end
+
+            it 'selects a managed VM size before preparing a heavy stemcell' do
+              allow(vm_manager2).to receive(:_get_stemcell_info).and_call_original
+              expect(instance_type_mapper).to receive(:filter_by_architecture)
+                .with(instance_types, 'Arm64', location)
+                .and_return(['Standard_D2ps_v5'])
+              expect(disk_manager2).to receive(:get_default_storage_account_type)
+                .with('Standard_D2ps_v5', location)
+                .and_return('Premium_LRS')
+              expect(stemcell_manager2).to receive(:get_user_image_info)
+                .with(stemcell_cid, 'Premium_LRS', location)
+                .and_return(stemcell_info)
+
+              vm_manager2.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+
+              expect(vm_props.instance_type).to eq('Standard_D2ps_v5')
+            end
+
+            it 'fails before creating network interfaces or a VM when no instance type is compatible' do
+              allow(instance_type_mapper).to receive(:filter_by_architecture)
+                .with(instance_types, 'Arm64', location)
+                .and_return([])
+              expect(azure_client).not_to receive(:create_network_interface)
+              expect(azure_client).not_to receive(:create_virtual_machine)
+
+              expect do
+                vm_manager.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+              end.to raise_error(/No available instance type supports stemcell architecture 'Arm64'/)
+            end
+
+            it 'reports VM SKU lookup failures as retryable' do
+              allow(instance_type_mapper).to receive(:filter_by_architecture)
+                .with(instance_types, 'Arm64', location)
+                .and_raise(Bosh::AzureCloud::InstanceTypeMapper::SkuLookupError, 'Failed to fetch VM SKU information: Azure API error')
+              expect(vm_manager).not_to receive(:_get_stemcell_info)
+              expect(azure_client).not_to receive(:create_network_interface)
+              expect(azure_client).not_to receive(:create_virtual_machine)
+
+              expect do
+                vm_manager.create(bosh_vm_meta, location, vm_props, disk_cids, network_configurator, env, agent_util, network_spec, config)
+              end.to raise_error(Bosh::Clouds::VMCreationFailed) { |error|
+                expect(error.ok_to_retry).to be(true)
+                expect(error.message).to include('Failed to fetch VM SKU information: Azure API error')
+              }
+            end
+          end
+
           context 'when disk_cids are not provided' do
             let(:disk_cids) { nil }
 

--- a/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
+++ b/src/bosh_azure_cpi/spec/unit/vm_manager/create/shared_stuff.rb
@@ -23,11 +23,12 @@ shared_context 'shared stuff for vm manager' do
   let(:stemcell_manager) { instance_double(Bosh::AzureCloud::StemcellManager) }
   let(:stemcell_manager2) { instance_double(Bosh::AzureCloud::StemcellManager2) }
   let(:light_stemcell_manager) { instance_double(Bosh::AzureCloud::LightStemcellManager) }
+  let(:instance_type_mapper) { instance_double(Bosh::AzureCloud::InstanceTypeMapper) }
   let(:blob_manager) { instance_double(Bosh::AzureCloud::BlobManager) }
   # VM manager for unmanaged disks
-  let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, disk_manager, disk_manager2, azure_client, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
+  let(:vm_manager) { Bosh::AzureCloud::VMManager.new(azure_config, disk_manager, disk_manager2, azure_client, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager, instance_type_mapper) }
   # VM manager for managed disks
-  let(:vm_manager2) { Bosh::AzureCloud::VMManager.new(azure_config_managed, disk_manager, disk_manager2, azure_client, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager) }
+  let(:vm_manager2) { Bosh::AzureCloud::VMManager.new(azure_config_managed, disk_manager, disk_manager2, azure_client, storage_account_manager, stemcell_manager, stemcell_manager2, light_stemcell_manager, instance_type_mapper) }
   # Parameters of create
   let(:instance_id) { instance_double(Bosh::AzureCloud::InstanceId) }
   let(:location) { 'fake-location' }
@@ -85,6 +86,15 @@ shared_context 'shared stuff for vm manager' do
       .and_return(nil)
     allow(stemcell_info).to receive(:is_light_stemcell?)
       .and_return(false)
+    allow(stemcell_info).to receive(:architecture)
+      .and_return(Bosh::AzureCloud::Helpers::CpuArchitecture::X64)
+    allow(stemcell_manager).to receive(:get_stemcell_architecture)
+      .and_return(Bosh::AzureCloud::Helpers::CpuArchitecture::X64)
+    allow(stemcell_manager2).to receive(:get_stemcell_architecture)
+      .and_return(Bosh::AzureCloud::Helpers::CpuArchitecture::X64)
+    allow(instance_type_mapper).to receive(:filter_by_architecture) do |instance_types, _architecture, _location|
+      instance_types
+    end
   end
 
   # AzureClient


### PR DESCRIPTION
# Checklist:

Please check each of the boxes below for which you have completed the corresponding task:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All unit tests pass locally (after my changes)
- [x] Rubocop reports zero errors (after my changes)

# Changelog

* Filter calculated Azure VM sizes using the stemcell architecture and CpuArchitectureType capability.

Resolves #750